### PR TITLE
Add instructions for setting up rabbitmq locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,23 @@ Write this later.
 Testing
 -------
 
-The configuration you need to test this can be created from `user-config-example.yml`. Simply copy it over to `user-config.yml` and fill in the blanks.
-`npm install` and `npm test`. You can set `DEBUG=taskcluster-pulse,test` if you want to see what's going on.
+Steps before running the test:
+
+1. Install rabbitmq locally:
+   * macOS: `brew update && brew install rabbitmq`
+   * Linux: install rabbitmq from the repository of your distribution
+2. Enable management API: `rabbitmq-plugins enable rabbitmq_management`
+3. Start rabbitmq: `rabbitmq-server`.
+4. Create a `user-config.yml`: copy over `user-config-example.yml` (it has the default
+   user, password and port of rabbitmq filled in).
+5. `npm install`
+
+To run the test, use `npm test`. You can set `DEBUG=taskcluster-pulse,test` if you want to
+see what's going on.
+
+After each test, flush rabbitmq database with `rabbitmqctl reset`. (The test suite adds
+and removes users during the test. Flushing the database ensures nothing is leaked between
+tests.)
 
 ## Post-Deployment Verification
 

--- a/user-config-example.yml
+++ b/user-config-example.yml
@@ -1,6 +1,6 @@
 ---
 defaults:
   rabbit:
-    username: '...'
-    password: '...'
-    baseUrl:  '...'
+    username: 'guest'
+    password: 'guest'
+    baseUrl:  'http://localhost:15672/api'


### PR DESCRIPTION
For now, local rabbitmq is required to run the tests.

(We will be adding tests requiring a local rabbitmq with administrative permission fairly soon.)