### PR TITLE
Make tests run with local rabbitmq in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-sudo: false
+sudo: required # We must use sudo here to have rabbitmq running :(
 env:
   global:
   - DEBUG='base:app:request,auth:*,server,test:*,pulse'
@@ -9,6 +9,8 @@ node_js:
 cache:
   directories:
     - node_modules
+services:
+  - rabbitmq
 addons:
   apt:
     sources:

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Steps before running the test:
 1. Install rabbitmq locally:
    * macOS: `brew update && brew install rabbitmq`
    * Linux: install rabbitmq from the repository of your distribution
-2. Enable management API: `rabbitmq-plugins enable rabbitmq_management`
-3. Start rabbitmq: `rabbitmq-server`.
+2. Start rabbitmq: `rabbitmq-server`.
+3. Enable management API: `rabbitmq-plugins enable rabbitmq_management`
 4. Create a `user-config.yml`: copy over `user-config-example.yml` (it has the default
    user, password and port of rabbitmq filled in).
 5. `npm install`


### PR DESCRIPTION
This makes it run with a local rabbitmq in travis as well.

I've assigned all of you just as a heads-up that you'll need to rebase on top of this for your tests to pass in travis. I can help with that if you want. But also one (or more!) of you could review this if you'd like and then we can merge it.