### PR TITLE
Can send messages to queues

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: node lib/main server
+expireNamespaces: node lib/main expire-namespaces

--- a/config.yml
+++ b/config.yml
@@ -3,7 +3,7 @@ defaults:
   app:
     # Prefix for exchanges, should always be v1/
     exchangePrefix: v1/
-    namespaceTableName: 'Namespaces'
+    namespaceTableName: 'PulseNamespaces'
     namespacesExpirationDelay: '- 1 hour'
 
   aws:

--- a/config.yml
+++ b/config.yml
@@ -32,6 +32,9 @@ defaults:
   azure:
     account:        !env AZURE_ACCOUNT_NAME
 
+  stressor:
+    amqpUrl:                  !env STRESSOR_AMQP_URL
+
 production:
   server:
     forceSSL:                 true
@@ -52,4 +55,4 @@ test:
   azure:
     account:  "inMemory"
 
-   
+

--- a/config.yml
+++ b/config.yml
@@ -3,6 +3,8 @@ defaults:
   app:
     # Prefix for exchanges, should always be v1/
     exchangePrefix: v1/
+    namespaceTableName: 'Namespaces'
+    namespacesExpirationDelay: '- 1 hour'
 
   aws:
     accessKeyId:      !env AWS_ACCESS_KEY_ID
@@ -27,6 +29,9 @@ defaults:
     password:                 !env RABBIT_PASSWORD
     baseUrl:                  !env RABBIT_BASE_URL
 
+  azure:
+    account:        !env AZURE_ACCOUNT_NAME
+
 production:
   server:
     forceSSL:                 true
@@ -34,9 +39,17 @@ production:
     env:                      'production'
 
 test:
+  app:
+    namespacesExpirationDelay: '0 hours'
+
   server:
     publicUrl:        http://localhost:60403
     port:             60403
     forceSSL:         false
     trustProxy:       false
     env:              development
+
+  azure:
+    account:  "inMemory"
+
+   

--- a/src/data.js
+++ b/src/data.js
@@ -1,0 +1,37 @@
+let assert = require('assert');
+let Entity = require('azure-entities');
+
+/**
+ * Entity for keeping track of pulse user credentials
+ *
+ */
+let Namespace = Entity.configure({
+  version:          1,
+  partitionKey:     Entity.keys.StringKey('namespace'),
+  rowKey:           Entity.keys.StringKey('username'),
+  properties: {
+    namespace:      Entity.types.String,
+    username:       Entity.types.String,
+    password:       Entity.types.String,
+    created:        Entity.types.Date,
+    expires:        Entity.types.Date,
+  },
+});
+
+Namespace.expire = async function(now) {
+  assert(now instanceof Date, 'now must be given as option');
+  var count = 0;
+  await Entity.scan.call(this, {
+    expires:          Entity.op.lessThan(now),
+  }, {
+    limit:            250, // max number of concurrent delete operations
+    handler:          (ns) => {
+      count++;
+      return ns.remove(true);
+    },
+  });
+  return count;
+};
+
+module.exports = {Namespace};
+

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ let _                 = require('lodash');
 let v1                = require('./api');
 let Rabbit            = require('./rabbitmanager');
 let data              = require('./data');
+let Stressor          = require('./rabbitstressor.js');
 
 // Create component loader
 let load = loader({
@@ -60,12 +61,12 @@ let load = loader({
     setup: async ({cfg, monitor}) => {
       var ns = data.Namespace.setup({
         account: cfg.azure.account,
-        table: cfg.app.namespaceTableName, 
+        table: cfg.app.namespaceTableName,
         credentials: cfg.taskcluster.credentials,
         monitor: monitor.prefix(cfg.app.namespaceTableName.toLowerCase()),
       });
 
-      await ns.ensureTable(); //create the table 
+      await ns.ensureTable(); //create the table
       return ns;
     },
   },
@@ -85,7 +86,11 @@ let load = loader({
       monitor.stopResourceMonitoring();
       await monitor.flush();
     },
+  },
 
+  stressor: {
+    requires: ['cfg'],
+    setup: ({cfg}) => new Stressor(cfg.stressor),
   },
 
   api: {

--- a/src/rabbitmanager.js
+++ b/src/rabbitmanager.js
@@ -158,6 +158,14 @@ class RabbitManager {
     const uriEncodedComponents = this.encodeURIComponents({name: name, vhost: vhost});
     return await this.request(`queues/${uriEncodedComponents.vhost}/${uriEncodedComponents.name}`, {method: 'delete'});
   }
+
+  async messagesFromQueue(queueName, options={count: 5, requeue: true, encoding:'auto'}, vhost='/') {
+    vhost = encodeURIComponent(vhost);
+    return await this.request(`queues/${vhost}/${queueName}/get`, {
+      body: JSON.stringify(options),
+      method: 'post',
+    });
+  }
 }
 
 module.exports = RabbitManager;

--- a/src/rabbitmanager.js
+++ b/src/rabbitmanager.js
@@ -166,6 +166,14 @@ class RabbitManager {
       method: 'post',
     });
   }
+
+  async messagesFromQueue(queueName, options={count: 5, requeue: true, encoding:'auto'}, vhost='/') {
+    vhost = encodeURIComponent(vhost);
+    return await this.request(`queues/${vhost}/${queueName}/get`, {
+      body: JSON.stringify(options),
+      method: 'post',
+    });
+  }
 }
 
 module.exports = RabbitManager;

--- a/src/rabbitmanager.js
+++ b/src/rabbitmanager.js
@@ -160,16 +160,11 @@ class RabbitManager {
   }
 
   async messagesFromQueue(queueName, options={count: 5, requeue: true, encoding:'auto'}, vhost='/') {
-    vhost = encodeURIComponent(vhost);
-    return await this.request(`queues/${vhost}/${queueName}/get`, {
-      body: JSON.stringify(options),
-      method: 'post',
-    });
-  }
-
-  async messagesFromQueue(queueName, options={count: 5, requeue: true, encoding:'auto'}, vhost='/') {
-    vhost = encodeURIComponent(vhost);
-    return await this.request(`queues/${vhost}/${queueName}/get`, {
+    if (!this.queueNameExists(queueName)) {
+      return;
+    }
+    const uriEncodedComponents = this.encodeURIComponents({queueName: queueName, vhost: vhost});
+    return await this.request(`queues/${uriEncodedComponents.vhost}/${uriEncodedComponents.queueName}/get`, {
       body: JSON.stringify(options),
       method: 'post',
     });

--- a/src/rabbitmanager.js
+++ b/src/rabbitmanager.js
@@ -90,7 +90,7 @@ class RabbitManager {
       return comparator(combiner(tags, userListTokens).length, 0);
     });
   }
- 
+
   async userPermissions(user, vhost='/') {
     vhost = encodeURIComponent(vhost);
     return await this.request(`permissions/${vhost}/${user}`);
@@ -112,6 +112,51 @@ class RabbitManager {
   async deleteUserPermissions(user, vhost='/') {
     vhost = encodeURIComponent(vhost);
     await this.request(`permissions/${vhost}/${user}`, {method: 'DELETE'});
+  }
+
+  async queues() {
+    return await this.request('queues');
+  }
+
+  queueNameExists(name) {
+    if (!name) {
+      console.warn('Please provide a name for the queue!');
+      return false;
+    }
+    return true;
+  }
+
+  encodeURIComponents(components) {
+    const result = {};
+    Object.keys(components).forEach(key => result[key] = encodeURIComponent(components[key]));
+    return result;
+  }
+
+  async queue(name, vhost='/') {
+    if (!this.queueNameExists(name)) {
+      return;
+    }
+    const uriEncodedComponents = this.encodeURIComponents({name: name, vhost: vhost});
+    return await this.request(`queues/${uriEncodedComponents.vhost}/${uriEncodedComponents.name}`);
+  }
+
+  async createQueue(name, options={}, vhost='/') {
+    if (!this.queueNameExists(name)) {
+      return;
+    }
+    const uriEncodedComponents = this.encodeURIComponents({name: name, vhost: vhost});
+    return await this.request(`queues/${uriEncodedComponents.vhost}/${uriEncodedComponents.name}`, {
+      body: JSON.stringify(options),
+      method: 'put',
+    });
+  }
+
+  async deleteQueue(name, vhost='/') {
+    if (!this.queueNameExists(name)) {
+      return;
+    }
+    const uriEncodedComponents = this.encodeURIComponents({name: name, vhost: vhost});
+    return await this.request(`queues/${uriEncodedComponents.vhost}/${uriEncodedComponents.name}`, {method: 'delete'});
   }
 }
 

--- a/src/rabbitstressor.js
+++ b/src/rabbitstressor.js
@@ -1,0 +1,26 @@
+/**
+ * An interface to stress test RabbitMQ queues.
+ */
+
+const amqp = require('amqplib');
+const assert = require('assert');
+
+class RabbitStressor {
+  constructor({amqpUrl}) {
+    assert(amqpUrl, 'Must provide an AMQP URL!');
+    this.connect(amqpUrl);
+  }
+
+  async connect(amqpUrl) {
+    this.connection = await amqp.connect(amqpUrl);
+    this.channel = await this.connection.createChannel();
+  }
+
+  sendMessages(queueName, messages) {
+    assert(messages instanceof Array);
+    this.channel.assertQueue(queueName, {durable: false});
+    messages.forEach(message => this.channel.sendToQueue(queueName, new Buffer(message)));
+  }
+}
+
+module.exports = RabbitStressor;

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -1,6 +1,8 @@
 suite('API', () => {
   let assert = require('assert');
+  let taskcluster = require('taskcluster-client');
   let helper = require('./helper');
+  let slugid = require('slugid');
 
   test('ping', () => {
     return helper.pulse.ping();
@@ -9,5 +11,111 @@ suite('API', () => {
   test('overview', () => {
     return helper.pulse.overview();
   });
+  
+  /////////////////////use continuation tokens for all namespace scan methods
+
+  test('expire namespace - no entries', async () => {
+    await helper.Namespaces.expire(taskcluster.fromNow('0 hours'));
+
+    var count = 0;
+    await helper.Namespaces.scan({}, 
+      {
+        limit:            250, // max number of concurrent delete operations
+        handler:          (ns) => {
+          count++;
+        },
+      });
+    
+    assert(count===0, 'expired namespace not removed');
+  });
+
+  test('expire namespace - one entry', async () => {
+    await helper.Namespaces.create({
+      namespace: 'e1',
+      username: slugid.v4(),
+      password: slugid.v4(),
+      created:  new Date(),
+      expires:  taskcluster.fromNow('- 1 day'),
+    });
+
+    await helper.Namespaces.expire(taskcluster.fromNow('0 hours'));
+
+    var count = 0;
+    await helper.Namespaces.scan({}, 
+      {
+        limit:            250, // max number of concurrent delete operations
+        handler:          (ns) => {
+          count++;
+        },
+      });
+    
+    assert(count===0, 'expired namespace not removed');
+  });
+
+  test('expire namespace - expire two entries', async () => {
+    await helper.Namespaces.create({
+      namespace: 'e1',
+      username: slugid.v4(),
+      password: slugid.v4(),
+      created:  new Date(),
+      expires:  taskcluster.fromNow('- 1 day'),
+    });
+
+    await helper.Namespaces.create({
+      namespace: 'e2',
+      username: slugid.v4(),
+      password: slugid.v4(),
+      created:  new Date(),
+      expires:  taskcluster.fromNow('- 1 day'),
+    });
+
+    await helper.Namespaces.expire(taskcluster.fromNow('0 hours'));
+
+    var count = 0;
+    await helper.Namespaces.scan({}, 
+      {
+        limit:            250, // max number of concurrent delete operations
+        handler:          (ns) => {
+          count++;
+        },
+      });
+    
+    assert(count===0, 'expired namespaces not removed');
+  });
+
+  test('expire namespace - expire one of two entries', async () => {
+    await helper.Namespaces.create({
+      namespace: 'e1',
+      username: slugid.v4(),
+      password: slugid.v4(),
+      created:  new Date(),
+      expires:  taskcluster.fromNow('- 1 day'),
+    });
+
+    await helper.Namespaces.create({
+      namespace: 'e2',
+      username: slugid.v4(),
+      password: slugid.v4(),
+      created:  new Date(),
+      expires:  taskcluster.fromNow('1 day'),
+    });
+
+    await helper.Namespaces.expire(taskcluster.fromNow('0 hours'));
+
+    var count = 0;
+    var name = '';
+    await helper.Namespaces.scan({}, 
+      {
+        limit:            250, // max number of concurrent delete operations
+        handler:          (ns) => {
+          name=ns.namespace;
+          count++;
+        },
+      });
+    
+    assert(count===1, 'one namespace should still be active');
+    assert(name==='e2', 'wrong namespace removed');
+  });
+
 });
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -10,6 +10,7 @@ let api         = require('../lib/api');
 let load        = require('../lib/main');
 let Rabbit      = require('../lib/rabbitmanager');
 let data        = require('../lib/data');
+let Stressor    = require('../lib/rabbitstressor');
 
 // Load configuration
 let cfg = config({profile: 'test'});
@@ -44,7 +45,7 @@ mocha.before(async () => {
   });
 
   helper.rabbit = new Rabbit(cfg.rabbit);
-  
+  helper.stressor = new Stressor(cfg.stressor);
 });
 
 mocha.after(async () => {
@@ -57,7 +58,7 @@ mocha.beforeEach(async () =>{
   helper.Namespaces = await load('Namespaces', {profile: 'test', process: 'test'});
 
   //ensureTable actually instantiates the table if non-existing. Supposed to be idempotent, but not
-  await helper.Namespaces.ensureTable();  
+  await helper.Namespaces.ensureTable();
 });
 
 mocha.afterEach(async () => {

--- a/test/helper.js
+++ b/test/helper.js
@@ -9,6 +9,7 @@ let testing     = require('taskcluster-lib-testing');
 let api         = require('../lib/api');
 let load        = require('../lib/main');
 let Rabbit      = require('../lib/rabbitmanager');
+let data        = require('../lib/data');
 
 // Load configuration
 let cfg = config({profile: 'test'});
@@ -43,9 +44,23 @@ mocha.before(async () => {
   });
 
   helper.rabbit = new Rabbit(cfg.rabbit);
+  
 });
 
 mocha.after(async () => {
   await webServer.terminate();
   testing.fakeauth.stop();
+});
+
+mocha.beforeEach(async () =>{
+  //set up the namespace entities
+  helper.Namespaces = await load('Namespaces', {profile: 'test', process: 'test'});
+
+  //ensureTable actually instantiates the table if non-existing. Supposed to be idempotent, but not
+  await helper.Namespaces.ensureTable();  
+});
+
+mocha.afterEach(async () => {
+  //remove the namespace entities
+  await  helper.Namespaces.removeTable();
 });

--- a/test/rabbit_stressor_test.js
+++ b/test/rabbit_stressor_test.js
@@ -25,11 +25,9 @@ suite('Rabbit Stressor', () => {
 
     const messagesFromQueue = await helper.rabbit.messagesFromQueue(queueName);
 
-    assert.equal(messagesFromQueue[0].payload, messages[0]);
-    assert.equal(messagesFromQueue[1].payload, messages[1]);
-    assert.equal(messagesFromQueue[2].payload, messages[2]);
-    assert.equal(messagesFromQueue[3].payload, messages[3]);
-    assert.equal(messagesFromQueue[4].payload, messages[4]);
+    messages.forEach((message, index) => {
+      assert.equal(messagesFromQueue[index].payload, message);
+    });
 
     await helper.rabbit.deleteQueue(queueName);
   });

--- a/test/rabbit_stressor_test.js
+++ b/test/rabbit_stressor_test.js
@@ -1,0 +1,37 @@
+suite('Rabbit Stressor', () => {
+  const assert = require('assert');
+  const _ = require('lodash');
+  const helper = require('./helper');
+
+  test('connect', async () => {
+    await helper.stressor.connect('amqp://localhost');
+  });
+
+  test('connectError', async () => {
+    try {
+      await helper.stressor.connect('not an amqp url');
+      assert.equal(true, false);
+    } catch (error) {
+      assert(error);
+    }
+  });
+
+  test('sendStringMessages', async () => {
+    const queueName = 'stress queue';
+    const messages = ['some', 'string', 'messages', 'being', 'sent'];
+
+    await helper.rabbit.createQueue(queueName);
+    helper.stressor.sendMessages(queueName, messages);
+
+    const messagesFromQueue = await helper.rabbit.messagesFromQueue(queueName);
+
+    assert.equal(messagesFromQueue[0].payload, messages[0]);
+    assert.equal(messagesFromQueue[1].payload, messages[1]);
+    assert.equal(messagesFromQueue[2].payload, messages[2]);
+    assert.equal(messagesFromQueue[3].payload, messages[3]);
+    assert.equal(messagesFromQueue[4].payload, messages[4]);
+
+    await helper.rabbit.deleteQueue(queueName);
+  });
+
+});

--- a/test/rabbit_test.js
+++ b/test/rabbit_test.js
@@ -108,4 +108,41 @@ suite('Rabbit Wrapper', () => {
     }
     await helper.rabbit.deleteUser(name);
   });
+
+  test('queues', async () => {
+    // Setup
+    const queueName = 'Temp queue';
+    await helper.rabbit.createQueue(queueName);
+
+    const queues = await helper.rabbit.queues();
+    assert(queues instanceof Array);
+    assert(_.has(queues[0], 'memory'));
+    assert(_.has(queues[0], 'messages'));
+    assert(_.has(queues[0], 'messages_details'));
+    assert(_.has(queues[0], 'messages_ready'));
+    assert(_.has(queues[0], 'name'));
+
+    // Teardown
+    await helper.rabbit.deleteQueue(queueName);
+  });
+
+  test('createGetDeleteQueue', async () => {
+    const queueName = 'My message queue';
+    await helper.rabbit.createQueue(queueName);
+
+    const queue = await helper.rabbit.queue(queueName);
+    assert.equal(queue.name, queueName);
+
+    await helper.rabbit.deleteQueue(queueName);
+  });
+
+  test('deleteQueueNotFoundException', async () => {
+    try {
+      const queueName = 'not a queue';
+      await helper.rabbit.deleteQueue(queueName);
+      assert.equal(true, false);
+    } catch (error) {
+      assert.equal(error.statusCode, 404);
+    }
+  });
 });

--- a/test/rabbit_test.js
+++ b/test/rabbit_test.js
@@ -115,6 +115,7 @@ suite('Rabbit Wrapper', () => {
     await helper.rabbit.createQueue(queueName);
 
     const queues = await helper.rabbit.queues();
+
     assert(queues instanceof Array);
     assert(_.has(queues[0], 'memory'));
     assert(_.has(queues[0], 'messages'));
@@ -144,5 +145,24 @@ suite('Rabbit Wrapper', () => {
     } catch (error) {
       assert.equal(error.statusCode, 404);
     }
+  });
+
+  test('messagesFromQueue', async () => {
+    const queueName = 'temp';
+    const messages = ['some', 'messages'];
+    await helper.rabbit.createQueue(queueName);
+    helper.stressor.sendMessages(queueName, messages);
+
+    const dequeuedMessages = await helper.rabbit.messagesFromQueue(queueName);
+
+    assert(dequeuedMessages instanceof Array);
+    assert(_.has(dequeuedMessages[0], 'payload_bytes'));
+    assert(_.has(dequeuedMessages[0], 'redelivered'));
+    assert(_.has(dequeuedMessages[0], 'exchange'));
+    assert(_.has(dequeuedMessages[0], 'routing_key'));
+    assert(_.has(dequeuedMessages[0], 'message_count'));
+    assert(_.has(dequeuedMessages[0], 'properties'));
+
+    await helper.rabbit.deleteQueue(queueName);
   });
 });

--- a/user-config-example.yml
+++ b/user-config-example.yml
@@ -4,3 +4,6 @@ defaults:
     username: 'guest'
     password: 'guest'
     baseUrl:  'http://localhost:15672/api'
+
+  stressor:
+    amqpUrl:  'amqp://localhost'


### PR DESCRIPTION
This is part of creating the Rabbit Stressor. I decided to make a Rabbit Stressor such that we can control the **rate** and **quantity** of messages uploaded to a RabbitMQ queue. This way, we can test the performance of the queue and get more insights to creating a more meaningful alert.

In config.yml, you may notice a new **stressor** configuration. So far, all this needs is an AMQP URL. For test purposes, I decided to go with amqp://localhost.

I also added the ability to read messages from queues (could be useful, plus it implements part of the RabbitMQ API).

**NOTE**: This also overlaps with my previous pull request for the **queues** branch. (This branch needed the ability to read queues and delete them for testing purposes).