### PR TITLE
add namespace contact information

### DIFF
--- a/schemas/namespace-request.yml
+++ b/schemas/namespace-request.yml
@@ -1,0 +1,23 @@
+$schema:  http://json-schema.org/draft-04/schema#
+title:                      "Namespace Creation Request"
+description: |
+  Namespace creation request
+type: object
+properties:
+  contact:
+    type:           object
+    title:          Contact Information
+    description:    The contact Information
+    properties:
+        method:
+            type:           string
+            title:          Contact Method
+            description:    "The contact method (eg. irc, email)"
+        id:
+            type:           string
+            title:          The contact id
+            description:    "The contact id (eg. username, email address)"
+additionalProperties: false
+required:
+  - contact
+

--- a/src/api.js
+++ b/src/api.js
@@ -65,10 +65,11 @@ api.declare({
 
 api.declare({
 /*Gets the namespace, creates one if one doesn't exist*/
-  method:   'get',
+  method:   'post',
   route:    '/namespace/:namespace',
   name:     'namespace',
   title:    'Create a namespace',	
+  input:    'namespace-request.json',
   scopes:   [
     ['pulse:namespace:<namespace>'],
   ],
@@ -80,7 +81,8 @@ api.declare({
   ].join('\n'),
 }, async function(req, res) {
  
-  let {namespace} = req.params;
+  let {namespace} = req.params; //the namespace requested
+  let contact = req.body.contact; //the contact information
 
   //check for any entries that contain the requested namespace
   let data = await this.Namespaces.query({
@@ -90,7 +92,7 @@ api.declare({
   }
   );
 
-  var newNamespace;
+  let newNamespace; //the namespace that will be returned in the response
 
   if (data.entries.length === 0) {
     //create a new entry if none exists 
@@ -101,6 +103,7 @@ api.declare({
       password: slugid.v4(),
       created:  new Date(),
       expires:  taskcluster.fromNow('1 day'),
+      contact:  contact,
     });
 
     await this.rabbit.createUser(newNamespace.username, newNamespace.password, ['taskcluster-pulse']);
@@ -118,6 +121,7 @@ api.declare({
       namespace: newNamespace.namespace,
       username: newNamespace.username,
       password: newNamespace.password,
+      contact:  newNamespace.contact,
     }
    
   );

--- a/src/data.js
+++ b/src/data.js
@@ -15,6 +15,15 @@ let Namespace = Entity.configure({
     password:       Entity.types.String,
     created:        Entity.types.Date,
     expires:        Entity.types.Date,
+
+  /**
+   * Contact object with properties
+   * -method
+   * -id
+   * 
+   * See JSON schema for documentation
+   */
+    contact:        Entity.types.JSON,
   },
 });
 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -12,6 +12,15 @@ suite('API', () => {
     return helper.pulse.overview();
   });
   
+  test('namespace', () => {
+    return helper.pulse.namespace('samplenamespace', {
+      contact: {
+        method: 'irc',
+        id:     'ircusername',
+      },
+    });
+  });
+
   /////////////////////use continuation tokens for all namespace scan methods
 
   test('expire namespace - no entries', async () => {
@@ -36,6 +45,7 @@ suite('API', () => {
       password: slugid.v4(),
       created:  new Date(),
       expires:  taskcluster.fromNow('- 1 day'),
+      contact:  {},
     });
 
     await helper.Namespaces.expire(taskcluster.fromNow('0 hours'));
@@ -52,13 +62,14 @@ suite('API', () => {
     assert(count===0, 'expired namespace not removed');
   });
 
-  test('expire namespace - expire two entries', async () => {
+  test('expire namespace - two entries', async () => {
     await helper.Namespaces.create({
       namespace: 'e1',
       username: slugid.v4(),
       password: slugid.v4(),
       created:  new Date(),
       expires:  taskcluster.fromNow('- 1 day'),
+      contact:  {},
     });
 
     await helper.Namespaces.create({
@@ -67,6 +78,7 @@ suite('API', () => {
       password: slugid.v4(),
       created:  new Date(),
       expires:  taskcluster.fromNow('- 1 day'),
+      contact:  {},
     });
 
     await helper.Namespaces.expire(taskcluster.fromNow('0 hours'));
@@ -83,13 +95,14 @@ suite('API', () => {
     assert(count===0, 'expired namespaces not removed');
   });
 
-  test('expire namespace - expire one of two entries', async () => {
+  test('expire namespace - one of two entries', async () => {
     await helper.Namespaces.create({
       namespace: 'e1',
       username: slugid.v4(),
       password: slugid.v4(),
       created:  new Date(),
       expires:  taskcluster.fromNow('- 1 day'),
+      contact:  {},
     });
 
     await helper.Namespaces.create({
@@ -98,6 +111,7 @@ suite('API', () => {
       password: slugid.v4(),
       created:  new Date(),
       expires:  taskcluster.fromNow('1 day'),
+      contact:  {},
     });
 
     await helper.Namespaces.expire(taskcluster.fromNow('0 hours'));


### PR DESCRIPTION
a few questions/comments:
1. Should the contact information be required with every request?
2. Should there be predefined contact method types (eg. only 'irc', 'emai', etc)? This would help cut down on some ambiguity (e-mail or email). 
3. I've changed the namespace api endpoint to be a post request since we are using the body to submit the contact information. Just wanted to make sure this was ok.