### PR TITLE
Alert temporary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /user-config.yml
 /lib
 /.test
+/.bin
 /node_modules
 
 # Vim

--- a/config.yml
+++ b/config.yml
@@ -3,7 +3,7 @@ defaults:
   app:
     # Prefix for exchanges, should always be v1/
     exchangePrefix: v1/
-    namespaceTableName: 'Namespaces'
+    namespaceTableName: 'PulseNamespaces'
     namespacesExpirationDelay: '- 1 hour'
 
   aws:

--- a/config.yml
+++ b/config.yml
@@ -32,6 +32,9 @@ defaults:
   azure:
     account:        !env AZURE_ACCOUNT_NAME
 
+  stressor:
+    amqpUrl:                  !env STRESSOR_AMQP_URL
+
 production:
   server:
     forceSSL:                 true
@@ -52,4 +55,4 @@ test:
   azure:
     account:  "inMemory"
 
-   
+

--- a/config.yml
+++ b/config.yml
@@ -30,7 +30,7 @@ defaults:
     baseUrl:                  !env RABBIT_BASE_URL
 
   azure:
-    account:        !env AZURE_ACCOUNT_NAME
+    account:                  !env AZURE_ACCOUNT_NAME
 
   stressor:
     amqpUrl:                  !env STRESSOR_AMQP_URL

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7,20 +7,42 @@
       "from": "accepts@>=1.3.3 <1.4.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz"
     },
-    "ajv": {
-      "version": "3.8.10",
-      "from": "ajv@>=3.8.5 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-3.8.10.tgz"
+    "acorn": {
+      "version": "4.0.3",
+      "from": "acorn@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz"
     },
-    "amdefine": {
-      "version": "1.0.0",
-      "from": "amdefine@>=0.0.4",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "from": "acorn-jsx@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "from": "acorn@>=3.0.4 <4.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+        }
+      }
+    },
+    "ajv": {
+      "version": "4.7.5",
+      "from": "ajv@>=4.7.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.7.5.tgz"
+    },
+    "ajv-keywords": {
+      "version": "1.1.1",
+      "from": "ajv-keywords@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.1.1.tgz"
     },
     "amqplib": {
       "version": "0.4.2",
       "from": "amqplib@>=0.4.0 <0.5.0",
       "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.2.tgz"
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "from": "ansi-escapes@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
@@ -43,24 +65,39 @@
       "resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz"
     },
     "argparse": {
-      "version": "1.0.7",
+      "version": "1.0.9",
       "from": "argparse@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz"
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz"
     },
     "array-flatten": {
       "version": "1.1.1",
       "from": "array-flatten@1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
     },
+    "array-union": {
+      "version": "1.0.2",
+      "from": "array-union@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz"
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "from": "array-uniq@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "from": "arrify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+    },
     "asap": {
-      "version": "2.0.4",
+      "version": "2.0.5",
       "from": "asap@>=2.0.3 <2.1.0",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
     },
     "asn1": {
-      "version": "0.1.11",
-      "from": "asn1@0.1.11",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+      "version": "0.2.3",
+      "from": "asn1@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "assert": {
       "version": "1.4.1",
@@ -93,9 +130,9 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
     },
     "aws-sdk": {
-      "version": "2.6.3",
+      "version": "2.6.5",
       "from": "aws-sdk@>=2.5.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.6.3.tgz"
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.6.5.tgz"
     },
     "aws-sdk-promise": {
       "version": "0.0.2",
@@ -125,9 +162,8 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
     },
     "azure-entities": {
-      "version": "1.0.2",
-      "from": "azure-entities@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/azure-entities/-/azure-entities-1.0.2.tgz",
+      "version": "1.0.3",
+      "from": "azure-entities@>=1.0.3 <2.0.0",
       "dependencies": {
         "asap": {
           "version": "1.0.0",
@@ -163,6 +199,11 @@
       "from": "azure-table-node@1.4.1",
       "resolved": "https://registry.npmjs.org/azure-table-node/-/azure-table-node-1.4.1.tgz",
       "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "from": "asn1@0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+        },
         "assert-plus": {
           "version": "0.1.5",
           "from": "assert-plus@>=0.1.5 <0.2.0",
@@ -200,8 +241,7 @@
           "dependencies": {
             "async": {
               "version": "0.9.2",
-              "from": "async@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+              "from": "async@>=0.9.0 <0.10.0"
             }
           }
         },
@@ -258,9 +298,9 @@
       }
     },
     "babel-code-frame": {
-      "version": "6.11.0",
-      "from": "babel-code-frame@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.11.0.tgz"
+      "version": "6.16.0",
+      "from": "babel-code-frame@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
     },
     "babel-compile": {
       "version": "2.0.0",
@@ -268,14 +308,19 @@
       "resolved": "https://registry.npmjs.org/babel-compile/-/babel-compile-2.0.0.tgz"
     },
     "babel-core": {
-      "version": "6.14.0",
+      "version": "6.16.0",
       "from": "babel-core@>=6.7.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.14.0.tgz"
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.16.0.tgz"
+    },
+    "babel-eslint": {
+      "version": "6.1.2",
+      "from": "babel-eslint@>=6.1.2 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz"
     },
     "babel-generator": {
-      "version": "6.14.0",
-      "from": "babel-generator@>=6.14.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.14.0.tgz"
+      "version": "6.16.0",
+      "from": "babel-generator@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.16.0.tgz"
     },
     "babel-helper-call-delegate": {
       "version": "6.8.0",
@@ -313,19 +358,19 @@
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz"
     },
     "babel-helper-remap-async-to-generator": {
-      "version": "6.11.2",
-      "from": "babel-helper-remap-async-to-generator@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.11.2.tgz"
+      "version": "6.16.2",
+      "from": "babel-helper-remap-async-to-generator@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.16.2.tgz"
     },
     "babel-helper-replace-supers": {
-      "version": "6.14.0",
+      "version": "6.16.0",
       "from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.14.0.tgz"
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz"
     },
     "babel-helpers": {
-      "version": "6.8.0",
-      "from": "babel-helpers@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.8.0.tgz"
+      "version": "6.16.0",
+      "from": "babel-helpers@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz"
     },
     "babel-messages": {
       "version": "6.8.0",
@@ -343,9 +388,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz"
     },
     "babel-plugin-transform-async-to-generator": {
-      "version": "6.8.0",
+      "version": "6.16.0",
       "from": "babel-plugin-transform-async-to-generator@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.8.0.tgz"
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz"
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.8.0",
@@ -373,9 +418,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.9.0",
-      "from": "babel-plugin-transform-es2015-destructuring@>=6.9.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.9.0.tgz"
+      "version": "6.16.0",
+      "from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz"
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.8.0",
@@ -403,9 +448,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.14.0",
-      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.14.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.14.0.tgz"
+      "version": "6.16.0",
+      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz"
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.14.0",
@@ -423,9 +468,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-parameters": {
-      "version": "6.11.4",
-      "from": "babel-plugin-transform-es2015-parameters@>=6.9.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.11.4.tgz"
+      "version": "6.16.0",
+      "from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.16.0.tgz"
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.8.0",
@@ -458,9 +503,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz"
     },
     "babel-plugin-transform-regenerator": {
-      "version": "6.14.0",
-      "from": "babel-plugin-transform-regenerator@>=6.14.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.14.0.tgz"
+      "version": "6.16.1",
+      "from": "babel-plugin-transform-regenerator@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz"
     },
     "babel-plugin-transform-runtime": {
       "version": "6.15.0",
@@ -473,9 +518,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz"
     },
     "babel-preset-es2015": {
-      "version": "6.14.0",
+      "version": "6.16.0",
       "from": "babel-preset-es2015@>=6.9.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.14.0.tgz"
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz"
     },
     "babel-preset-taskcluster": {
       "version": "3.0.0",
@@ -483,24 +528,14 @@
       "resolved": "https://registry.npmjs.org/babel-preset-taskcluster/-/babel-preset-taskcluster-3.0.0.tgz"
     },
     "babel-register": {
-      "version": "6.14.0",
-      "from": "babel-register@>=6.14.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.14.0.tgz",
+      "version": "6.16.3",
+      "from": "babel-register@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
       "dependencies": {
         "core-js": {
           "version": "2.4.1",
           "from": "core-js@>=2.4.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-        },
-        "source-map": {
-          "version": "0.1.32",
-          "from": "source-map@0.1.32",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
-        },
-        "source-map-support": {
-          "version": "0.2.10",
-          "from": "source-map-support@>=0.2.10 <0.3.0",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz"
         }
       }
     },
@@ -517,24 +552,24 @@
       }
     },
     "babel-template": {
-      "version": "6.15.0",
-      "from": "babel-template@>=6.14.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.15.0.tgz"
+      "version": "6.16.0",
+      "from": "babel-template@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
     },
     "babel-traverse": {
-      "version": "6.15.0",
-      "from": "babel-traverse@>=6.14.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.15.0.tgz"
+      "version": "6.16.0",
+      "from": "babel-traverse@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz"
     },
     "babel-types": {
-      "version": "6.15.0",
-      "from": "babel-types@>=6.14.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.15.0.tgz"
+      "version": "6.16.0",
+      "from": "babel-types@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz"
     },
     "babylon": {
-      "version": "6.10.0",
-      "from": "babylon@>=6.9.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.10.0.tgz"
+      "version": "6.11.2",
+      "from": "babylon@>=6.11.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.2.tgz"
     },
     "balanced-match": {
       "version": "0.4.2",
@@ -542,9 +577,9 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "base64-js": {
-      "version": "1.1.2",
+      "version": "1.2.0",
       "from": "base64-js@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
     },
     "base64-url": {
       "version": "1.3.2",
@@ -554,7 +589,14 @@
     "base64url": {
       "version": "1.0.6",
       "from": "base64url@>=1.0.4 <1.1.0",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.4.10",
+          "from": "concat-stream@>=1.4.7 <1.5.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz"
+        }
+      }
     },
     "basic-auth": {
       "version": "1.0.4",
@@ -564,14 +606,7 @@
     "bcrypt-pbkdf": {
       "version": "1.0.0",
       "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-      "dependencies": {
-        "tweetnacl": {
-          "version": "0.14.3",
-          "from": "tweetnacl@>=0.14.3 <0.15.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
     },
     "bindings": {
       "version": "1.2.1",
@@ -585,7 +620,7 @@
     },
     "bl": {
       "version": "1.1.2",
-      "from": "bl@>=1.0.0 <2.0.0",
+      "from": "bl@>=1.1.2 <1.2.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "dependencies": {
         "readable-stream": {
@@ -672,6 +707,16 @@
       "from": "bytes@2.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
     },
+    "caller-path": {
+      "version": "0.1.0",
+      "from": "caller-path@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz"
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "from": "callsites@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
+    },
     "camelcase": {
       "version": "1.2.1",
       "from": "camelcase@>=1.0.1 <2.0.0",
@@ -709,10 +754,30 @@
       "from": "chalk@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
+    "circular-json": {
+      "version": "0.3.1",
+      "from": "circular-json@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz"
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "from": "cli-cursor@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
+    },
+    "cli-width": {
+      "version": "2.1.0",
+      "from": "cli-width@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
+    },
     "co": {
       "version": "4.6.0",
       "from": "co@>=4.6.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+    },
+    "code-point-at": {
+      "version": "1.0.0",
+      "from": "code-point-at@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
     },
     "combined-stream": {
       "version": "0.0.7",
@@ -735,9 +800,16 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
-      "version": "1.4.10",
-      "from": "concat-stream@>=1.4.7 <1.5.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz"
+      "version": "1.5.2",
+      "from": "concat-stream@>=1.4.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.0.6",
+          "from": "readable-stream@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+        }
+      }
     },
     "content-disposition": {
       "version": "0.5.1",
@@ -804,6 +876,11 @@
       "from": "ctype@0.5.3",
       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
     },
+    "d": {
+      "version": "0.1.1",
+      "from": "d@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+    },
     "dashdash": {
       "version": "1.14.0",
       "from": "dashdash@>=1.12.0 <2.0.0",
@@ -831,6 +908,16 @@
       "from": "deep-equal@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "from": "deep-is@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+    },
+    "del": {
+      "version": "2.2.2",
+      "from": "del@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz"
+    },
     "delayed-stream": {
       "version": "0.0.5",
       "from": "delayed-stream@0.0.5",
@@ -855,6 +942,11 @@
       "version": "1.4.0",
       "from": "diff@1.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+    },
+    "doctrine": {
+      "version": "1.4.0",
+      "from": "doctrine@>=1.2.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.4.0.tgz"
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -910,6 +1002,36 @@
       "from": "error-ex@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
     },
+    "es5-ext": {
+      "version": "0.10.12",
+      "from": "es5-ext@>=0.10.11 <0.11.0",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
+    },
+    "es6-iterator": {
+      "version": "2.0.0",
+      "from": "es6-iterator@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+    },
+    "es6-map": {
+      "version": "0.1.4",
+      "from": "es6-map@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz"
+    },
+    "es6-set": {
+      "version": "0.1.4",
+      "from": "es6-set@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
+    },
+    "es6-symbol": {
+      "version": "3.1.0",
+      "from": "es6-symbol@>=3.1.0 <3.2.0",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
+    },
+    "es6-weak-map": {
+      "version": "2.0.1",
+      "from": "es6-weak-map@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz"
+    },
     "escape-html": {
       "version": "1.0.3",
       "from": "escape-html@>=1.0.3 <1.1.0",
@@ -920,10 +1042,64 @@
       "from": "escape-string-regexp@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
+    "escope": {
+      "version": "3.6.0",
+      "from": "escope@>=3.6.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz"
+    },
+    "eslint": {
+      "version": "2.13.1",
+      "from": "eslint@>=2.8.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "dependencies": {
+        "globals": {
+          "version": "9.10.0",
+          "from": "globals@>=9.2.0 <10.0.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.10.0.tgz"
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "from": "user-home@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
+        }
+      }
+    },
+    "eslint-config-taskcluster": {
+      "version": "2.0.0",
+      "from": "eslint-config-taskcluster@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-taskcluster/-/eslint-config-taskcluster-2.0.0.tgz"
+    },
+    "eslint-plugin-taskcluster": {
+      "version": "1.0.2",
+      "from": "eslint-plugin-taskcluster@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-taskcluster/-/eslint-plugin-taskcluster-1.0.2.tgz"
+    },
+    "espree": {
+      "version": "3.3.2",
+      "from": "espree@>=3.1.6 <4.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.3.2.tgz"
+    },
     "esprima": {
       "version": "2.7.3",
       "from": "esprima@>=2.6.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+    },
+    "esrecurse": {
+      "version": "4.1.0",
+      "from": "esrecurse@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+      "dependencies": {
+        "estraverse": {
+          "version": "4.1.1",
+          "from": "estraverse@>=4.1.0 <4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "from": "estraverse@>=4.2.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
     },
     "esutils": {
       "version": "2.0.2",
@@ -935,10 +1111,20 @@
       "from": "etag@>=1.7.0 <1.8.0",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
     },
+    "event-emitter": {
+      "version": "0.3.4",
+      "from": "event-emitter@>=0.3.4 <0.4.0",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+    },
     "eventsource": {
       "version": "0.1.6",
       "from": "eventsource@>=0.1.6 <0.2.0",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz"
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "from": "exit-hook@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
     },
     "express": {
       "version": "4.14.0",
@@ -965,15 +1151,35 @@
       "from": "fast-azure-storage@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/fast-azure-storage/-/fast-azure-storage-0.3.5.tgz"
     },
+    "fast-levenshtein": {
+      "version": "2.0.5",
+      "from": "fast-levenshtein@>=2.0.4 <2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz"
+    },
     "faye-websocket": {
       "version": "0.11.0",
       "from": "faye-websocket@>=0.11.0 <0.12.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz"
     },
+    "figures": {
+      "version": "1.7.0",
+      "from": "figures@>=1.3.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz"
+    },
+    "file-entry-cache": {
+      "version": "1.3.1",
+      "from": "file-entry-cache@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz"
+    },
     "finalhandler": {
       "version": "0.5.0",
       "from": "finalhandler@0.5.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz"
+    },
+    "flat-cache": {
+      "version": "1.2.1",
+      "from": "flat-cache@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.1.tgz"
     },
     "fn.name": {
       "version": "1.0.1",
@@ -1065,14 +1271,24 @@
       }
     },
     "glob": {
-      "version": "7.0.6",
+      "version": "7.1.0",
       "from": "glob@>=7.0.5 <8.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz"
+    },
+    "glob-all": {
+      "version": "3.1.0",
+      "from": "glob-all@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/glob-all/-/glob-all-3.1.0.tgz"
     },
     "globals": {
       "version": "8.18.0",
       "from": "globals@>=8.3.0 <9.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
+    },
+    "globby": {
+      "version": "5.0.0",
+      "from": "globby@>=5.0.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz"
     },
     "got": {
       "version": "5.6.0",
@@ -1085,6 +1301,11 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
         }
       }
+    },
+    "graceful-fs": {
+      "version": "4.1.9",
+      "from": "graceful-fs@>=4.1.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -1151,6 +1372,16 @@
       "from": "ieee754@>=1.1.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
     },
+    "ignore": {
+      "version": "3.1.5",
+      "from": "ignore@>=3.1.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.1.5.tgz"
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "from": "imurmurhash@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+    },
     "indent-string": {
       "version": "1.2.2",
       "from": "indent-string@>=1.1.0 <2.0.0",
@@ -1165,6 +1396,11 @@
       "version": "2.0.1",
       "from": "inherits@2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+    },
+    "inquirer": {
+      "version": "0.12.0",
+      "from": "inquirer@>=0.12.0 <0.13.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz"
     },
     "invariant": {
       "version": "2.2.1",
@@ -1186,10 +1422,30 @@
       "from": "is-finite@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
     },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+    },
     "is-my-json-valid": {
       "version": "2.14.0",
-      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+      "from": "is-my-json-valid@>=2.10.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz"
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "from": "is-path-cwd@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
+    },
+    "is-path-inside": {
+      "version": "1.0.0",
+      "from": "is-path-inside@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -1205,6 +1461,11 @@
       "version": "1.0.0",
       "from": "is-redirect@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
+    },
+    "is-resolvable": {
+      "version": "1.0.0",
+      "from": "is-resolvable@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz"
     },
     "is-retry-allowed": {
       "version": "1.1.0",
@@ -1248,7 +1509,7 @@
     },
     "js-yaml": {
       "version": "3.6.1",
-      "from": "js-yaml@>=3.5.3 <4.0.0",
+      "from": "js-yaml@>=3.5.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz"
     },
     "jsbn": {
@@ -1257,9 +1518,9 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
     },
     "jsesc": {
-      "version": "0.5.0",
-      "from": "jsesc@>=0.5.0 <0.6.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+      "version": "1.3.0",
+      "from": "jsesc@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1273,7 +1534,7 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "json3": {
@@ -1316,15 +1577,20 @@
       "from": "jws@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.3.tgz"
     },
+    "levn": {
+      "version": "0.3.0",
+      "from": "levn@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
+    },
     "libxmljs": {
       "version": "0.18.0",
       "from": "libxmljs@>=0.18.0 <0.19.0",
       "resolved": "https://registry.npmjs.org/libxmljs/-/libxmljs-0.18.0.tgz"
     },
     "lodash": {
-      "version": "4.16.0",
+      "version": "4.16.2",
       "from": "lodash@>=4.15.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.0.tgz"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz"
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -1351,6 +1617,11 @@
       "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "from": "lodash.assign@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
+    },
     "lodash.create": {
       "version": "3.1.1",
       "from": "lodash.create@3.1.1",
@@ -1370,6 +1641,11 @@
       "version": "3.1.2",
       "from": "lodash.keys@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+    },
+    "lodash.pickby": {
+      "version": "4.6.0",
+      "from": "lodash.pickby@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz"
     },
     "loose-envify": {
       "version": "1.2.0",
@@ -1462,6 +1738,33 @@
         }
       }
     },
+    "mocha-eslint": {
+      "version": "3.0.1",
+      "from": "mocha-eslint@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/mocha-eslint/-/mocha-eslint-3.0.1.tgz",
+      "dependencies": {
+        "eslint": {
+          "version": "3.6.1",
+          "from": "eslint@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.6.1.tgz"
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "from": "file-entry-cache@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz"
+        },
+        "globals": {
+          "version": "9.10.0",
+          "from": "globals@>=9.2.0 <10.0.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.10.0.tgz"
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "from": "user-home@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
+        }
+      }
+    },
     "morgan": {
       "version": "1.7.0",
       "from": "morgan@>=1.5.2 <2.0.0",
@@ -1477,6 +1780,11 @@
       "from": "ms@0.7.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
     },
+    "mute-stream": {
+      "version": "0.0.5",
+      "from": "mute-stream@0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+    },
     "mz": {
       "version": "2.4.0",
       "from": "mz@>=2.4.0 <3.0.0",
@@ -1486,6 +1794,11 @@
       "version": "2.3.2",
       "from": "nan@2.3.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz"
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "from": "natural-compare@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
     },
     "negotiator": {
       "version": "0.6.1",
@@ -1511,7 +1824,7 @@
     },
     "node-uuid": {
       "version": "1.4.7",
-      "from": "node-uuid@>=1.4.1 <1.5.0",
+      "from": "node-uuid@>=1.4.7 <1.5.0",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "number-is-nan": {
@@ -1549,6 +1862,16 @@
       "from": "once@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
     },
+    "onetime": {
+      "version": "1.1.0",
+      "from": "onetime@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "from": "optionator@>=0.8.1 <0.9.0",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz"
+    },
     "original": {
       "version": "1.0.0",
       "from": "original@>=0.0.5",
@@ -1560,6 +1883,11 @@
           "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz"
         }
       }
+    },
+    "os-homedir": {
+      "version": "1.0.1",
+      "from": "os-homedir@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
     },
     "os-tmpdir": {
       "version": "1.0.1",
@@ -1586,6 +1914,11 @@
       "from": "path-is-absolute@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
     },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "from": "path-is-inside@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "from": "path-to-regexp@0.1.7",
@@ -1595,6 +1928,11 @@
       "version": "0.1.1",
       "from": "pathval@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz"
+    },
+    "pify": {
+      "version": "2.3.0",
+      "from": "pify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
       "version": "2.0.4",
@@ -1611,6 +1949,16 @@
       "from": "pixl-xml@>=1.0.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/pixl-xml/-/pixl-xml-1.0.9.tgz"
     },
+    "pluralize": {
+      "version": "1.2.1",
+      "from": "pluralize@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "from": "prelude-ls@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+    },
     "prepend-http": {
       "version": "1.0.4",
       "from": "prepend-http@>=1.0.1 <2.0.0",
@@ -1625,6 +1973,11 @@
       "version": "1.0.7",
       "from": "process-nextick-args@>=1.0.6 <1.1.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+    },
+    "progress": {
+      "version": "1.1.8",
+      "from": "progress@>=1.1.8 <2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
     },
     "promise": {
       "version": "7.1.1",
@@ -1649,12 +2002,29 @@
     "pulse-publisher": {
       "version": "1.1.1",
       "from": "pulse-publisher@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pulse-publisher/-/pulse-publisher-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/pulse-publisher/-/pulse-publisher-1.1.1.tgz",
+      "dependencies": {
+        "ajv": {
+          "version": "3.8.10",
+          "from": "ajv@>=3.8.5 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-3.8.10.tgz"
+        }
+      }
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "from": "punycode@1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
     },
     "qs": {
       "version": "6.2.0",
       "from": "qs@6.2.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "from": "querystring@0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
     },
     "querystringify": {
       "version": "0.0.4",
@@ -1719,6 +2089,11 @@
         }
       }
     },
+    "readline2": {
+      "version": "1.0.1",
+      "from": "readline2@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
+    },
     "recursive-readdir-sync": {
       "version": "1.0.6",
       "from": "recursive-readdir-sync@>=1.0.6 <2.0.0",
@@ -1752,16 +2127,28 @@
     "regjsparser": {
       "version": "0.1.5",
       "from": "regjsparser@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "from": "jsesc@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+        }
+      }
     },
     "repeating": {
       "version": "1.1.3",
       "from": "repeating@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
     },
+    "replaceall": {
+      "version": "0.1.6",
+      "from": "replaceall@>=0.1.6 <0.2.0",
+      "resolved": "https://registry.npmjs.org/replaceall/-/replaceall-0.1.6.tgz"
+    },
     "request": {
       "version": "2.75.0",
-      "from": "request@latest",
+      "from": "request@>=2.75.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
       "dependencies": {
         "combined-stream": {
@@ -1788,7 +2175,7 @@
     },
     "request-promise": {
       "version": "4.1.1",
-      "from": "request-promise@latest",
+      "from": "request-promise@>=4.1.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.1.1.tgz"
     },
     "request-promise-core": {
@@ -1796,15 +2183,45 @@
       "from": "request-promise-core@1.1.1",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz"
     },
+    "require-uncached": {
+      "version": "1.0.2",
+      "from": "require-uncached@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz"
+    },
+    "requireindex": {
+      "version": "1.1.0",
+      "from": "requireindex@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz"
+    },
     "requires-port": {
       "version": "1.0.0",
       "from": "requires-port@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
     },
+    "resolve-from": {
+      "version": "1.0.1",
+      "from": "resolve-from@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "from": "restore-cursor@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
+    },
     "rimraf": {
       "version": "2.5.4",
       "from": "rimraf@>=2.4.3 <3.0.0",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "from": "run-async@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz"
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "from": "rx-lite@>=3.1.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
     },
     "s3-upload-stream": {
       "version": "1.0.7",
@@ -1836,10 +2253,20 @@
       "from": "shebang-regex@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
+    "shelljs": {
+      "version": "0.6.1",
+      "from": "shelljs@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz"
+    },
     "slash": {
       "version": "1.0.0",
       "from": "slash@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "from": "slice-ansi@0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
     },
     "slugid": {
       "version": "1.1.0",
@@ -1862,16 +2289,9 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
     },
     "source-map-support": {
-      "version": "0.4.2",
-      "from": "source-map-support@latest",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.2.tgz",
-      "dependencies": {
-        "source-map": {
-          "version": "0.1.32",
-          "from": "source-map@0.1.32",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
-        }
-      }
+      "version": "0.4.3",
+      "from": "source-map-support@>=0.4.2 <0.5.0",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz"
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1879,15 +2299,10 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sshpk": {
-      "version": "1.10.0",
+      "version": "1.10.1",
       "from": "sshpk@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
       "dependencies": {
-        "asn1": {
-          "version": "0.2.3",
-          "from": "asn1@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-        },
         "assert-plus": {
           "version": "1.0.0",
           "from": "assert-plus@>=1.0.0 <2.0.0",
@@ -1920,6 +2335,11 @@
       "from": "string_decoder@>=0.10.0 <0.11.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
+    "string-width": {
+      "version": "1.0.2",
+      "from": "string-width@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+    },
     "stringstream": {
       "version": "0.0.5",
       "from": "stringstream@>=0.0.4 <0.1.0",
@@ -1929,6 +2349,16 @@
       "version": "3.0.1",
       "from": "strip-ansi@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "from": "strip-bom@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "from": "strip-json-comments@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
     "superagent": {
       "version": "1.7.2",
@@ -1999,6 +2429,11 @@
       "from": "supports-color@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
+    "table": {
+      "version": "3.8.0",
+      "from": "table@>=3.7.8 <4.0.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.0.tgz"
+    },
     "tar-stream": {
       "version": "1.5.2",
       "from": "tar-stream@>=1.5.2 <2.0.0",
@@ -2044,14 +2479,12 @@
           "resolved": "https://registry.npmjs.org/taskcluster-lib-docs/-/taskcluster-lib-docs-1.0.3.tgz",
           "dependencies": {
             "asap": {
-              "version": "2.0.4",
-              "from": "asap@~2.0.3",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.4.tgz"
+              "version": "2.0.5",
+              "from": "asap@>=2.0.3 <2.1.0"
             },
             "promise": {
               "version": "7.1.1",
-              "from": "promise@^7.0.4",
-              "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
+              "from": "promise@>=7.0.4 <8.0.0"
             }
           }
         },
@@ -2061,14 +2494,12 @@
           "resolved": "https://registry.npmjs.org/taskcluster-lib-monitor/-/taskcluster-lib-monitor-3.1.0.tgz",
           "dependencies": {
             "asap": {
-              "version": "2.0.4",
-              "from": "asap@~2.0.3",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.4.tgz"
+              "version": "2.0.5",
+              "from": "asap@>=2.0.3 <2.1.0"
             },
             "promise": {
               "version": "7.1.1",
-              "from": "promise@^7.0.4",
-              "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
+              "from": "promise@>=7.0.4 <8.0.0"
             }
           }
         },
@@ -2122,6 +2553,11 @@
           "version": "1.1.4",
           "from": "accepts@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz"
+        },
+        "ajv": {
+          "version": "3.8.10",
+          "from": "ajv@>=3.8.5 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-3.8.10.tgz"
         },
         "component-emitter": {
           "version": "1.1.2",
@@ -2721,65 +3157,10 @@
       "from": "taskcluster-lib-iterate@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/taskcluster-lib-iterate/-/taskcluster-lib-iterate-1.0.2.tgz",
       "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "from": "assert-plus@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "from": "aws-sign2@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "from": "delayed-stream@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-        },
-        "form-data": {
-          "version": "2.0.0",
-          "from": "form-data@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz"
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "from": "hawk@>=3.1.3 <3.2.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "from": "http-signature@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.1 <0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-        },
-        "request": {
-          "version": "2.75.0",
-          "from": "request@>=2.73.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz"
-        },
         "request-promise": {
           "version": "3.0.0",
           "from": "request-promise@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-3.0.0.tgz"
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "from": "tunnel-agent@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         }
       }
     },
@@ -2843,9 +3224,9 @@
       }
     },
     "taskcluster-lib-monitor": {
-      "version": "4.3.0",
+      "version": "4.3.1",
       "from": "taskcluster-lib-monitor@>=4.2.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/taskcluster-lib-monitor/-/taskcluster-lib-monitor-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/taskcluster-lib-monitor/-/taskcluster-lib-monitor-4.3.1.tgz",
       "dependencies": {
         "statsum": {
           "version": "0.5.1",
@@ -2954,11 +3335,6 @@
           "version": "1.1.4",
           "from": "accepts@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz"
-        },
-        "ajv": {
-          "version": "4.7.2",
-          "from": "ajv@>=4.0.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.7.2.tgz"
         },
         "asap": {
           "version": "1.0.0",
@@ -3279,18 +3655,15 @@
             },
             "component-emitter": {
               "version": "1.2.1",
-              "from": "component-emitter@~1.2.0",
-              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
+              "from": "component-emitter@>=1.2.0 <1.3.0"
             },
             "cookiejar": {
               "version": "2.0.6",
-              "from": "cookiejar@2.0.6",
-              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz"
+              "from": "cookiejar@2.0.6"
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+              "from": "extend@3.0.0"
             },
             "form-data": {
               "version": "1.0.0-rc3",
@@ -3299,8 +3672,7 @@
             },
             "hawk": {
               "version": "2.3.1",
-              "from": "hawk@^2.3.1",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz"
+              "from": "hawk@>=2.3.1 <3.0.0"
             },
             "lodash": {
               "version": "3.10.1",
@@ -3309,23 +3681,19 @@
             },
             "methods": {
               "version": "1.1.2",
-              "from": "methods@~1.1.1",
-              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+              "from": "methods@>=1.1.1 <1.2.0"
             },
             "mime": {
               "version": "1.3.4",
-              "from": "mime@1.3.4",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+              "from": "mime@1.3.4"
             },
             "mime-db": {
               "version": "1.24.0",
-              "from": "mime-db@~1.24.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+              "from": "mime-db@>=1.24.0 <1.25.0"
             },
             "mime-types": {
               "version": "2.1.12",
-              "from": "mime-types@^2.1.3",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
+              "from": "mime-types@>=2.1.3 <3.0.0"
             },
             "promise": {
               "version": "6.1.0",
@@ -3344,8 +3712,7 @@
             },
             "superagent-hawk": {
               "version": "0.0.6",
-              "from": "superagent-hawk@^0.0.6",
-              "resolved": "https://registry.npmjs.org/superagent-hawk/-/superagent-hawk-0.0.6.tgz",
+              "from": "superagent-hawk@>=0.0.6 <0.0.7",
               "dependencies": {
                 "boom": {
                   "version": "0.4.2",
@@ -3381,8 +3748,7 @@
             },
             "superagent-promise": {
               "version": "0.2.0",
-              "from": "superagent-promise@^0.2.0",
-              "resolved": "https://registry.npmjs.org/superagent-promise/-/superagent-promise-0.2.0.tgz"
+              "from": "superagent-promise@>=0.2.0 <0.3.0"
             }
           }
         },
@@ -3392,9 +3758,8 @@
           "resolved": "https://registry.npmjs.org/taskcluster-lib-validate/-/taskcluster-lib-validate-1.1.1.tgz",
           "dependencies": {
             "lodash": {
-              "version": "4.16.0",
-              "from": "lodash@^4.5.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.0.tgz"
+              "version": "4.16.2",
+              "from": "lodash@>=4.5.1 <5.0.0"
             },
             "url-join": {
               "version": "1.1.0",
@@ -3420,17 +3785,17 @@
       "from": "taskcluster-lib-validate@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/taskcluster-lib-validate/-/taskcluster-lib-validate-2.0.0.tgz",
       "dependencies": {
-        "ajv": {
-          "version": "4.7.2",
-          "from": "ajv@>=4.0.4 <5.0.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.7.2.tgz"
-        },
         "url-join": {
           "version": "1.1.0",
           "from": "url-join@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz"
         }
       }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "from": "text-table@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
     },
     "thenify": {
       "version": "3.2.0",
@@ -3441,6 +3806,11 @@
       "version": "1.6.0",
       "from": "thenify-all@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
+    },
+    "through": {
+      "version": "2.3.8",
+      "from": "through@>=2.3.6 <3.0.0",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
       "version": "0.6.5",
@@ -3476,8 +3846,13 @@
     },
     "tough-cookie": {
       "version": "2.3.1",
-      "from": "tough-cookie@>=0.12.0",
+      "from": "tough-cookie@>=2.3.0 <2.4.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
+    },
+    "tryit": {
+      "version": "1.0.2",
+      "from": "tryit@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
     },
     "tunnel-agent": {
       "version": "0.4.3",
@@ -3485,9 +3860,14 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
     },
     "tweetnacl": {
-      "version": "0.13.3",
-      "from": "tweetnacl@>=0.13.0 <0.14.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+      "version": "0.14.3",
+      "from": "tweetnacl@>=0.14.0 <0.15.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "from": "type-check@>=0.3.2 <0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
     },
     "type-detect": {
       "version": "0.1.1",
@@ -3518,6 +3898,11 @@
       "version": "1.0.1",
       "from": "unzip-response@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.1.tgz"
+    },
+    "url": {
+      "version": "0.10.3",
+      "from": "url@0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz"
     },
     "url-join": {
       "version": "0.0.1",
@@ -3594,10 +3979,20 @@
       "from": "when@>=3.6.2 <3.7.0",
       "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz"
     },
+    "wordwrap": {
+      "version": "1.0.0",
+      "from": "wordwrap@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+    },
     "wrappy": {
       "version": "1.0.2",
       "from": "wrappy@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+    },
+    "write": {
+      "version": "0.2.1",
+      "from": "write@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
     },
     "xml2js": {
       "version": "0.4.15",
@@ -3618,8 +4013,20 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <4.1.0-0",
+      "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+    },
+    "yargs": {
+      "version": "1.2.6",
+      "from": "yargs@>=1.2.6 <1.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.1.0",
+          "from": "minimist@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz"
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "assume": "^1.4.1",
     "aws-sdk": "^2.5.3",
-    "azure-entities": "^1.0.2",
+    "azure-entities": "^1.0.3",
     "babel-compile": "^2.0.0",
     "babel-eslint": "^6.1.2",
     "babel-preset-taskcluster": "^3.0.0",

--- a/schemas/namespace-request.yml
+++ b/schemas/namespace-request.yml
@@ -1,0 +1,23 @@
+$schema:  http://json-schema.org/draft-04/schema#
+title:                      "Namespace Creation Request"
+description: |
+  Namespace creation request
+type: object
+properties:
+  contact:
+    type:           object
+    title:          Contact Information
+    description:    The contact Information
+    properties:
+        method:
+            type:           string
+            title:          Contact Method
+            description:    "The contact method (eg. irc, email)"
+        id:
+            type:           string
+            title:          The contact id
+            description:    "The contact id (eg. username, email address)"
+additionalProperties: false
+required:
+  - contact
+

--- a/src/api.js
+++ b/src/api.js
@@ -65,10 +65,11 @@ api.declare({
 
 api.declare({
 /*Gets the namespace, creates one if one doesn't exist*/
-  method:   'get',
+  method:   'post',
   route:    '/namespace/:namespace',
   name:     'namespace',
   title:    'Create a namespace',	
+  input:    'namespace-request.json',
   scopes:   [
     ['pulse:namespace:<namespace>'],
   ],
@@ -80,7 +81,8 @@ api.declare({
   ].join('\n'),
 }, async function(req, res) {
  
-  let {namespace} = req.params;
+  let {namespace} = req.params; //the namespace requested
+  let contact = req.body.contact; //the contact information
 
   //check for any entries that contain the requested namespace
   let data = await this.Namespaces.query({
@@ -90,7 +92,7 @@ api.declare({
   }
   );
 
-  var newNamespace;
+  let newNamespace; //the namespace that will be returned in the response
 
   if (data.entries.length === 0) {
     //create a new entry if none exists 
@@ -101,6 +103,7 @@ api.declare({
       password: slugid.v4(),
       created:  new Date(),
       expires:  taskcluster.fromNow('1 day'),
+      contact:  contact,
     });
 
     await this.rabbit.createUser(newNamespace.username, newNamespace.password, ['taskcluster-pulse']);
@@ -118,6 +121,7 @@ api.declare({
       namespace: newNamespace.namespace,
       username: newNamespace.username,
       password: newNamespace.password,
+      contact:  newNamespace.contact,
     }
    
   );

--- a/src/data.js
+++ b/src/data.js
@@ -15,6 +15,15 @@ let Namespace = Entity.configure({
     password:       Entity.types.String,
     created:        Entity.types.Date,
     expires:        Entity.types.Date,
+
+  /**
+   * Contact object with properties
+   * -method
+   * -id
+   * 
+   * See JSON schema for documentation
+   */
+    contact:        Entity.types.JSON,
   },
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ let _                 = require('lodash');
 let v1                = require('./api');
 let Rabbit            = require('./rabbitmanager');
 let data              = require('./data');
+let Stressor          = require('./rabbitstressor.js');
 
 // Create component loader
 let load = loader({
@@ -60,12 +61,12 @@ let load = loader({
     setup: async ({cfg, monitor}) => {
       var ns = data.Namespace.setup({
         account: cfg.azure.account,
-        table: cfg.app.namespaceTableName, 
+        table: cfg.app.namespaceTableName,
         credentials: cfg.taskcluster.credentials,
         monitor: monitor.prefix(cfg.app.namespaceTableName.toLowerCase()),
       });
 
-      await ns.ensureTable(); //create the table 
+      await ns.ensureTable(); //create the table
       return ns;
     },
   },
@@ -85,7 +86,11 @@ let load = loader({
       monitor.stopResourceMonitoring();
       await monitor.flush();
     },
+  },
 
+  stressor: {
+    requires: ['cfg'],
+    setup: ({cfg}) => new Stressor(cfg.stressor),
   },
 
   api: {

--- a/src/rabbitmanager.js
+++ b/src/rabbitmanager.js
@@ -111,7 +111,7 @@ class RabbitManager {
 
   async deleteUserPermissions(user, vhost='/') {
     vhost = encodeURIComponent(vhost);
-    await this.request(`permissions/${vhost}/${user}`, {method: 'DELETE'});
+    await this.request(`permissions/${vhost}/${user}`, {method: 'delete'});
   }
 
   async queues() {

--- a/src/rabbitmanager.js
+++ b/src/rabbitmanager.js
@@ -158,6 +158,22 @@ class RabbitManager {
     const uriEncodedComponents = this.encodeURIComponents({name: name, vhost: vhost});
     return await this.request(`queues/${uriEncodedComponents.vhost}/${uriEncodedComponents.name}`, {method: 'delete'});
   }
+
+  async messagesFromQueue(queueName, options={count: 5, requeue: true, encoding:'auto'}, vhost='/') {
+    vhost = encodeURIComponent(vhost);
+    return await this.request(`queues/${vhost}/${queueName}/get`, {
+      body: JSON.stringify(options),
+      method: 'post',
+    });
+  }
+
+  async messagesFromQueue(queueName, options={count: 5, requeue: true, encoding:'auto'}, vhost='/') {
+    vhost = encodeURIComponent(vhost);
+    return await this.request(`queues/${vhost}/${queueName}/get`, {
+      body: JSON.stringify(options),
+      method: 'post',
+    });
+  }
 }
 
 module.exports = RabbitManager;

--- a/src/rabbitmanager.js
+++ b/src/rabbitmanager.js
@@ -160,16 +160,11 @@ class RabbitManager {
   }
 
   async messagesFromQueue(queueName, options={count: 5, requeue: true, encoding:'auto'}, vhost='/') {
-    vhost = encodeURIComponent(vhost);
-    return await this.request(`queues/${vhost}/${queueName}/get`, {
-      body: JSON.stringify(options),
-      method: 'post',
-    });
-  }
-
-  async messagesFromQueue(queueName, options={count: 5, requeue: true, encoding:'auto'}, vhost='/') {
-    vhost = encodeURIComponent(vhost);
-    return await this.request(`queues/${vhost}/${queueName}/get`, {
+    if (!this.queueNameExists(queueName)) {
+      return;
+    }
+    const uriEncodedComponents = this.encodeURIComponents({queueName: queueName, vhost: vhost});
+    return await this.request(`queues/${uriEncodedComponents.vhost}/${uriEncodedComponents.queueName}/get`, {
       body: JSON.stringify(options),
       method: 'post',
     });

--- a/src/rabbitstressor.js
+++ b/src/rabbitstressor.js
@@ -1,0 +1,26 @@
+/**
+ * An interface to stress test RabbitMQ queues.
+ */
+
+const amqp = require('amqplib');
+const assert = require('assert');
+
+class RabbitStressor {
+  constructor({amqpUrl}) {
+    assert(amqpUrl, 'Must provide an AMQP URL!');
+    this.connect(amqpUrl);
+  }
+
+  async connect(amqpUrl) {
+    this.connection = await amqp.connect(amqpUrl);
+    this.channel = await this.connection.createChannel();
+  }
+
+  sendMessages(queueName, messages) {
+    assert(messages instanceof Array);
+    this.channel.assertQueue(queueName, {durable: false});
+    messages.forEach(message => this.channel.sendToQueue(queueName, new Buffer(message)));
+  }
+}
+
+module.exports = RabbitStressor;

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -12,6 +12,15 @@ suite('API', () => {
     return helper.pulse.overview();
   });
   
+  test('namespace', () => {
+    return helper.pulse.namespace('samplenamespace', {
+      contact: {
+        method: 'irc',
+        id:     'ircusername',
+      },
+    });
+  });
+
   /////////////////////use continuation tokens for all namespace scan methods
 
   test('expire namespace - no entries', async () => {
@@ -36,6 +45,7 @@ suite('API', () => {
       password: slugid.v4(),
       created:  new Date(),
       expires:  taskcluster.fromNow('- 1 day'),
+      contact:  {},
     });
 
     await helper.Namespaces.expire(taskcluster.fromNow('0 hours'));
@@ -52,13 +62,14 @@ suite('API', () => {
     assert(count===0, 'expired namespace not removed');
   });
 
-  test('expire namespace - expire two entries', async () => {
+  test('expire namespace - two entries', async () => {
     await helper.Namespaces.create({
       namespace: 'e1',
       username: slugid.v4(),
       password: slugid.v4(),
       created:  new Date(),
       expires:  taskcluster.fromNow('- 1 day'),
+      contact:  {},
     });
 
     await helper.Namespaces.create({
@@ -67,6 +78,7 @@ suite('API', () => {
       password: slugid.v4(),
       created:  new Date(),
       expires:  taskcluster.fromNow('- 1 day'),
+      contact:  {},
     });
 
     await helper.Namespaces.expire(taskcluster.fromNow('0 hours'));
@@ -83,13 +95,14 @@ suite('API', () => {
     assert(count===0, 'expired namespaces not removed');
   });
 
-  test('expire namespace - expire one of two entries', async () => {
+  test('expire namespace - one of two entries', async () => {
     await helper.Namespaces.create({
       namespace: 'e1',
       username: slugid.v4(),
       password: slugid.v4(),
       created:  new Date(),
       expires:  taskcluster.fromNow('- 1 day'),
+      contact:  {},
     });
 
     await helper.Namespaces.create({
@@ -98,6 +111,7 @@ suite('API', () => {
       password: slugid.v4(),
       created:  new Date(),
       expires:  taskcluster.fromNow('1 day'),
+      contact:  {},
     });
 
     await helper.Namespaces.expire(taskcluster.fromNow('0 hours'));

--- a/test/helper.js
+++ b/test/helper.js
@@ -10,6 +10,7 @@ let api         = require('../lib/api');
 let load        = require('../lib/main');
 let Rabbit      = require('../lib/rabbitmanager');
 let data        = require('../lib/data');
+let Stressor    = require('../lib/rabbitstressor');
 
 // Load configuration
 let cfg = config({profile: 'test'});
@@ -44,7 +45,7 @@ mocha.before(async () => {
   });
 
   helper.rabbit = new Rabbit(cfg.rabbit);
-  
+  helper.stressor = new Stressor(cfg.stressor);
 });
 
 mocha.after(async () => {
@@ -57,7 +58,7 @@ mocha.beforeEach(async () =>{
   helper.Namespaces = await load('Namespaces', {profile: 'test', process: 'test'});
 
   //ensureTable actually instantiates the table if non-existing. Supposed to be idempotent, but not
-  await helper.Namespaces.ensureTable();  
+  await helper.Namespaces.ensureTable();
 });
 
 mocha.afterEach(async () => {

--- a/test/rabbit_stressor_test.js
+++ b/test/rabbit_stressor_test.js
@@ -25,11 +25,9 @@ suite('Rabbit Stressor', () => {
 
     const messagesFromQueue = await helper.rabbit.messagesFromQueue(queueName);
 
-    assert.equal(messagesFromQueue[0].payload, messages[0]);
-    assert.equal(messagesFromQueue[1].payload, messages[1]);
-    assert.equal(messagesFromQueue[2].payload, messages[2]);
-    assert.equal(messagesFromQueue[3].payload, messages[3]);
-    assert.equal(messagesFromQueue[4].payload, messages[4]);
+    messages.forEach((message, index) => {
+      assert.equal(messagesFromQueue[index].payload, message);
+    });
 
     await helper.rabbit.deleteQueue(queueName);
   });

--- a/test/rabbit_stressor_test.js
+++ b/test/rabbit_stressor_test.js
@@ -1,0 +1,37 @@
+suite('Rabbit Stressor', () => {
+  const assert = require('assert');
+  const _ = require('lodash');
+  const helper = require('./helper');
+
+  test('connect', async () => {
+    await helper.stressor.connect('amqp://localhost');
+  });
+
+  test('connectError', async () => {
+    try {
+      await helper.stressor.connect('not an amqp url');
+      assert.equal(true, false);
+    } catch (error) {
+      assert(error);
+    }
+  });
+
+  test('sendStringMessages', async () => {
+    const queueName = 'stress queue';
+    const messages = ['some', 'string', 'messages', 'being', 'sent'];
+
+    await helper.rabbit.createQueue(queueName);
+    helper.stressor.sendMessages(queueName, messages);
+
+    const messagesFromQueue = await helper.rabbit.messagesFromQueue(queueName);
+
+    assert.equal(messagesFromQueue[0].payload, messages[0]);
+    assert.equal(messagesFromQueue[1].payload, messages[1]);
+    assert.equal(messagesFromQueue[2].payload, messages[2]);
+    assert.equal(messagesFromQueue[3].payload, messages[3]);
+    assert.equal(messagesFromQueue[4].payload, messages[4]);
+
+    await helper.rabbit.deleteQueue(queueName);
+  });
+
+});

--- a/test/rabbit_test.js
+++ b/test/rabbit_test.js
@@ -115,6 +115,7 @@ suite('Rabbit Wrapper', () => {
     await helper.rabbit.createQueue(queueName);
 
     const queues = await helper.rabbit.queues();
+
     assert(queues instanceof Array);
     assert(_.has(queues[0], 'memory'));
     assert(_.has(queues[0], 'messages'));
@@ -143,6 +144,34 @@ suite('Rabbit Wrapper', () => {
       assert.equal(true, false);
     } catch (error) {
       assert.equal(error.statusCode, 404);
+    }
+  });
+
+  test('messagesFromQueue', async () => {
+    const queueName = 'temp';
+    const messages = ['some', 'messages'];
+    await helper.rabbit.createQueue(queueName);
+    helper.stressor.sendMessages(queueName, messages);
+
+    const dequeuedMessages = await helper.rabbit.messagesFromQueue(queueName);
+
+    assert(dequeuedMessages instanceof Array);
+    assert(_.has(dequeuedMessages[0], 'payload_bytes'));
+    assert(_.has(dequeuedMessages[0], 'redelivered'));
+    assert(_.has(dequeuedMessages[0], 'exchange'));
+    assert(_.has(dequeuedMessages[0], 'routing_key'));
+    assert(_.has(dequeuedMessages[0], 'message_count'));
+    assert(_.has(dequeuedMessages[0], 'properties'));
+
+    await helper.rabbit.deleteQueue(queueName);
+  });
+
+  test('deleteUserException', async () => {
+    try {
+      await helper.rabbit.deleteUser('not a user');
+      expect(true).to.be.false;
+    } catch (error) {
+      expect(error.statusCode).to.equal(404);
     }
   });
 });

--- a/test/rabbit_test.js
+++ b/test/rabbit_test.js
@@ -165,13 +165,4 @@ suite('Rabbit Wrapper', () => {
 
     await helper.rabbit.deleteQueue(queueName);
   });
-
-  test('deleteUserException', async () => {
-    try {
-      await helper.rabbit.deleteUser('not a user');
-      expect(true).to.be.false;
-    } catch (error) {
-      expect(error.statusCode).to.equal(404);
-    }
-  });
 });

--- a/user-config-example.yml
+++ b/user-config-example.yml
@@ -4,3 +4,6 @@ defaults:
     username: 'guest'
     password: 'guest'
     baseUrl:  'http://localhost:15672/api'
+
+  stressor:
+    amqpUrl:  'amqp://localhost'


### PR DESCRIPTION
So I managed to get the stressor tests running when rabbitstressor.js is in the bin/ directory. However, it looks like babel-compile only compiles files from one directory to another. I.e. it only supports one-to-one mapping. Therefore, in order to use rabbitstressor.js, I am importing from a .bin/ directory (notice this is a hidden directory, just like ./test). the require syntax looks a bit off. You can see what I mean in the latest commit.