### PR TITLE
API cleanup and idempotency checks

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -105,7 +105,7 @@ async function setNamespace(context, namespace) {
       user = await context.rabbit.createUser(newNamespace.username, newNamespace.password, ['taskcluster-pulse']),
       vhost             = '/',
       configurePattern  = '',
-      writePattern      = `taskcluster/(exchanges|queues)/ ${newNamespace.namespace} + /.*`,
+      writePattern      = `taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,
       readPattern       = 'taskcluster/exchanges/.*',
       ); 
   } catch (err) {

--- a/src/api.js
+++ b/src/api.js
@@ -88,8 +88,10 @@ api.declare({
   });
 });
 
-/* Attempt to create a new namespace entry and associated Rabbit user.
- * If the requested namespace exists, return it*/
+/* 
+ * Attempt to create a new namespace entry and associated Rabbit user.
+ * If the requested namespace exists, return it.
+ */
 async function setNamespace(context, namespace) {
   let newNamespace; 
   try {
@@ -109,7 +111,7 @@ async function setNamespace(context, namespace) {
       readPattern       = 'taskcluster/exchanges/.*',
       ); 
   } catch (err) {
-    if (!err || err.code !== 'EntityAlreadyExists') {
+    if (err.code !== 'EntityAlreadyExists') {
       throw err;
     }
     newNamespace = await context.Namespaces.load({namespace: namespace});

--- a/src/data.js
+++ b/src/data.js
@@ -8,7 +8,7 @@ let Entity = require('azure-entities');
 let Namespace = Entity.configure({
   version:          1,
   partitionKey:     Entity.keys.StringKey('namespace'),
-  rowKey:           Entity.keys.StringKey('username'),
+  rowKey:           Entity.keys.ConstantKey('namespace'),
   properties: {
     namespace:      Entity.types.String,
     username:       Entity.types.String,

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -103,8 +103,8 @@ suite('API', () => {
 
     await helper.Namespaces.expire(taskcluster.fromNow('0 hours'));
 
-    var count = 0;
-    var name = '';
+    let count = 0;
+    let name = '';
     await helper.Namespaces.scan({}, 
       {
         limit:            250, // max number of concurrent delete operations
@@ -123,23 +123,19 @@ suite('API', () => {
     let b = await helper.pulse.namespace('testname');
     assert(_.isEqual(a, b)); 
   });
-
+  
   test('"namespace" idempotency - entry creation', async () => {
     for (let i = 0; i < 10; i++) {
       await helper.pulse.namespace('testname');
     } 
-    var count = 0;
-    var name = '';
+    let count = 0;
     await helper.Namespaces.scan({}, 
       {
-        limit:            250, // max number of concurrent delete operations
+        limit:            250, 
         handler:          (ns) => {
-          name=ns.namespace;
           count++;
         },
       });
-
-    assert(count === 1, 'Exactly one entry should be created');
-    
+    assert.equal(count, 1);
   });
 });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -132,9 +132,7 @@ suite('API', () => {
     await helper.Namespaces.scan({}, 
       {
         limit:            250, 
-        handler:          (ns) => {
-          count++;
-        },
+        handler:          ns => count++,
       });
     assert.equal(count, 1);
   });


### PR DESCRIPTION
added read/write patterns to user creation & cleaned up a bit of logic.
'namespace' api endpoint was getting long and ugly, so I broke it up into a couple functions.
tested idempotency of namespace endpoint - not 100% sure if I'm missing something or not. 