### PR TITLE
Username rotations

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: node lib/main server
 expireNamespaces: node lib/main expire-namespaces
+rotateNamespaces: node lib/main rotate-namespaces

--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,7 @@ defaults:
     exchangePrefix: v1/
     namespaceTableName: 'PulseNamespaces'
     namespacesExpirationDelay: '- 1 hour'
+    namespacesRotationDelay: '- 1 hour'
 
   aws:
     accessKeyId:      !env AWS_ACCESS_KEY_ID

--- a/schemas/exchanges-response.yml
+++ b/schemas/exchanges-response.yml
@@ -1,0 +1,11 @@
+$schema:  http://json-schema.org/draft-04/schema#
+title:              "RabbitMQ Exchanges"
+description: |
+  An array of strings containing the names of exchanges in RabbitMQ
+type: array
+items:
+    type: string
+additionalProperties: false
+required:
+  - exchanges
+

--- a/schemas/namespace-response.yml
+++ b/schemas/namespace-response.yml
@@ -1,0 +1,32 @@
+$schema:  http://json-schema.org/draft-04/schema#
+title:              "Namespace Creation Response"
+description: |
+  Namespace creation response
+type: object
+properties:
+  namespace:
+    type:           string
+    title:          Namespace
+    description:    The name of the namespace created
+  username:
+    type:           string
+    title:          Username
+    description:    The username created for authentication
+  password:
+    type:           string
+    title:          Password
+    description:    The password created for authentication
+  contact:
+    type:           object
+    title:          Contact Information
+    description:    The contact information which will be handed off to the notification service  
+    oneOf:
+                    - {$ref: 'http://schemas.taskcluster.net/pulse/v1/irc-request.json#'}
+                    - {$ref: 'http://schemas.taskcluster.net/pulse/v1/email-request.json#'}
+additionalProperties: false
+required:
+  - namespace
+  - username
+  - password
+  - contact
+

--- a/src/api.js
+++ b/src/api.js
@@ -131,10 +131,21 @@ async function setNamespace(context, namespace, contact) {
     await context.rabbit.createUser(namespace.concat('-').concat('2'), newNamespace.password, ['taskcluster-pulse']);
     
     //set up user pairs in rabbitmq, both users are used for auth rotations
-    await context.rabbit.setUserPermissions(namespace.concat('-').concat('1'), '/', 'test',
-      `taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`, 'taskcluster/exchanges/.*'); 
-    await context.rabbit.setUserPermissions(namespace.concat('-').concat('2'), '/', 'test',
-      `taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`, 'taskcluster/exchanges/.*'); 
+    await context.rabbit.setUserPermissions(
+      namespace.concat('-1'),                                         //username
+      '/',                                                            //vhost
+      `taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //configure pattern
+      `taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //write pattern
+      'taskcluster/exchanges/.*'                                      //read pattern
+      ); 
+
+    await context.rabbit.setUserPermissions(
+      namespace.concat('-2'),                                         //username
+      '/',                                                            //vhost
+      `taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //configure pattern
+      `taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //write pattern
+      'taskcluster/exchanges/.*'                                      //read pattern
+      );   
     
   } catch (err) {
     if (err.code !== 'EntityAlreadyExists') {

--- a/src/api.js
+++ b/src/api.js
@@ -127,8 +127,8 @@ async function setNamespace(context, namespace, contact) {
       contact:    contact,
     });
     
-    await context.rabbit.createUser(namespace.concat('-').concat('1'), newNamespace.password, ['taskcluster-pulse']);
-    await context.rabbit.createUser(namespace.concat('-').concat('2'), newNamespace.password, ['taskcluster-pulse']);
+    await context.rabbit.createUser(namespace.concat('-1'), newNamespace.password, ['taskcluster-pulse']);
+    await context.rabbit.createUser(namespace.concat('-2'), newNamespace.password, ['taskcluster-pulse']);
     
     //set up user pairs in rabbitmq, both users are used for auth rotations
     await context.rabbit.setUserPermissions(

--- a/src/api.js
+++ b/src/api.js
@@ -32,7 +32,7 @@ api.declare({
   route:    '/overview',
   name:     'overview',
   title:    'Rabbit Overview',
-  output:	    'rabbit-overview.json',		
+  output:	  'rabbit-overview.json',		
   description: [
     'An overview of the Rabbit cluster',
     '',
@@ -55,6 +55,7 @@ api.declare({
   route:    '/exchanges',
   name:     'exchanges',
   title:    'Rabbit Exchanges',  
+  output:   'exchanges-response.json',
   description: [
     'A list of exchanges in the rabbit cluster',
     '',
@@ -78,6 +79,7 @@ api.declare({
   name:     'namespace',
   title:    'Create a namespace',	
   input:    'namespace-request.json',
+  output:   'namespace-response.json',
   scopes:   [
     ['pulse:namespace:<namespace>'],
   ],

--- a/src/api.js
+++ b/src/api.js
@@ -134,17 +134,17 @@ async function setNamespace(context, namespace, contact) {
     await context.rabbit.setUserPermissions(
       namespace.concat('-1'),                                         //username
       '/',                                                            //vhost
-      `taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //configure pattern
-      `taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //write pattern
-      'taskcluster/exchanges/.*'                                      //read pattern
+      `^taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //configure pattern
+      `^taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //write pattern
+      '^taskcluster/exchanges/.*'                                      //read pattern
       ); 
 
     await context.rabbit.setUserPermissions(
       namespace.concat('-2'),                                         //username
       '/',                                                            //vhost
-      `taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //configure pattern
-      `taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //write pattern
-      'taskcluster/exchanges/.*'                                      //read pattern
+      `^taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //configure pattern
+      `^taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //write pattern
+      '^taskcluster/exchanges/.*'                                      //read pattern
       );   
     
   } catch (err) {

--- a/src/data.js
+++ b/src/data.js
@@ -2,6 +2,7 @@ let assert = require('assert');
 let Entity = require('azure-entities');
 let taskcluster = require('taskcluster-client');
 let slugid = require('slugid');
+let RabbitManager = require('../lib/rabbitmanager');
 
 /**
  * Entity for keeping track of pulse user credentials
@@ -53,7 +54,7 @@ Namespace.expire = async function(now) {
 
 Namespace.rotate = async function(now, rabbit) {
   assert(now instanceof Date, 'now must be given as option');
-  //assert(rabbit instanceof RabbitManager, 'rabbit manager must be given as option');
+  assert(rabbit instanceof RabbitManager, 'rabbit manager must be given as option');
   
   var count = 0;
   await Entity.scan.call(this, {
@@ -66,6 +67,7 @@ Namespace.rotate = async function(now, rabbit) {
       var nextRotationState = ns.rotationState === '1' ? '2' : '1';
 
       //modify user in rabbitmq
+      //TODO: open issue to create editUser method for rabbitmq api
       await rabbit.createUser(ns.username.concat('-').concat(nextRotationState), nextPass, ['taskcluster-pulse']);
 
       //modify ns in table

--- a/src/data.js
+++ b/src/data.js
@@ -39,7 +39,7 @@ Namespace.getRotationUsername = function(ns) {
 
 Namespace.expire = async function(now) {
   assert(now instanceof Date, 'now must be given as option');
-  var count = 0;
+  let count = 0;
   await Entity.scan.call(this, {
     expires:          Entity.op.lessThan(now),
   }, {
@@ -56,15 +56,15 @@ Namespace.rotate = async function(now, rabbit) {
   assert(now instanceof Date, 'now must be given as option');
   assert(rabbit instanceof RabbitManager, 'rabbit manager must be given as option');
   
-  var count = 0;
+  let count = 0;
   await Entity.scan.call(this, {
     nextRotation:          Entity.op.lessThan(now),
   }, {
     limit:            250, // max number of concurrent modify operations
     handler:          async (ns) => {
       count++;
-      var nextPass = slugid.v4();
-      var nextRotationState = ns.rotationState === '1' ? '2' : '1';
+      let nextPass = slugid.v4();
+      let nextRotationState = ns.rotationState === '1' ? '2' : '1';
 
       //modify user in rabbitmq
       //TODO: open issue to create editUser method for rabbitmq api

--- a/src/main.js
+++ b/src/main.js
@@ -87,6 +87,23 @@ let load = loader({
     },
   },
 
+  'rotate-namespaces':{
+    requires: ['cfg', 'Namespaces', 'monitor', 'rabbit'],
+    setup: async ({cfg, Namespaces, monitor, rabbit}) => {
+      let now = taskcluster.fromNow(cfg.app.namespacesRotationDelay);
+      assert(!_.isNaN(now), 'Can\'t have NaN as now');
+
+      // rotate namespace username entries using delay
+      debug('Rotating namespace entry at: %s, from before %s', new Date(), now);
+      let count = await Namespaces.rotate(now, rabbit);
+      debug('Rotating %s namespace entries', count);
+
+      monitor.count('rotate-namespaces.done');
+      monitor.stopResourceMonitoring();
+      await monitor.flush();
+    },
+  },
+
   api: {
     requires: ['cfg', 'monitor', 'validator', 'rabbit', 'Namespaces'],
     setup: ({cfg, monitor, validator, rabbit, Namespaces}) => v1.setup({

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -97,7 +97,7 @@ suite('API', () => {
   test('expire namespace - no entries', async () => {
     await namespaces.expire(taskcluster.fromNow('0 hours'));
 
-    var count = 0;
+    let count = 0;
     await namespaces.scan({},
       {
         limit:            250, // max number of concurrent delete operations
@@ -123,7 +123,7 @@ suite('API', () => {
 
     await namespaces.expire(taskcluster.fromNow('0 hours'));
 
-    var count = 0;
+    let count = 0;
     await namespaces.scan({},
       {
         limit:            250, // max number of concurrent delete operations
@@ -160,7 +160,7 @@ suite('API', () => {
 
     await namespaces.expire(taskcluster.fromNow('0 hours'));
 
-    var count = 0;
+    let count = 0;
     await namespaces.scan({},
       {
         limit:            250, // max number of concurrent delete operations
@@ -261,7 +261,7 @@ suite('API', () => {
   test('rotate namespace - no entries', async () => {
     await namespaces.rotate(taskcluster.fromNow('0 hours'), helper.rabbit);
 
-    var count = 0;
+    let count = 0;
     await namespaces.scan({},
       {
         limit:            250, 


### PR DESCRIPTION
Currently creates two users in rabbitmq for auth rotations. Auth rotations are set to occur every hour. Procfile has been modified to call upon the rotation method.
Depending on the rotation state of the namespace entry, a different username/password combination will be given (eg. username-1 + pass1, username-2 + pass2). Every rotation changes the password of the credentials. 