### PR TITLE
Fix #39 (caused by typo)

### DIFF
--- a/test/rabbit_test.js
+++ b/test/rabbit_test.js
@@ -34,7 +34,7 @@ suite('Rabbit Wrapper', () => {
     }
     for (let queuename of queuenames) {
       try {
-        await helper.rabbit.deleteQuee(queuename);
+        await helper.rabbit.deleteQueue(queuename);
       } catch (e) {
         // Intentianlly do nothing since this queue might not have been created.
       }


### PR DESCRIPTION
Let's fix this obvious bug first, which is why we are leaking queues after tests. As for the user leakage, I'll investigate later and fix separately.

Really surprised there is no runtime exception whatsoever. Any good ways to prevent this kind of bugs?