### PR TITLE
Alerter

### DIFF
--- a/bin/rabbitmonitorrunner.js
+++ b/bin/rabbitmonitorrunner.js
@@ -1,0 +1,89 @@
+const config = require('typed-env-config');
+const testing = require('taskcluster-lib-testing');
+const api = require('../lib/api');
+const load = require('../lib/main');
+const RabbitAlerter = require('../lib/rabbitalerter');
+const RabbitManager = require('../lib/rabbitmanager');
+const RabbitMonitor = require('../lib/rabbitmonitor');
+const RabbitStressor = require('./rabbitstressor');
+const taskcluster = require('taskcluster-client');
+
+/**
+ *  Sets up the environment to run the RabbitMonitor.
+ *
+ *  @param {Object} cfg   - TaskCluster Configuration Object
+ */
+const setup = async (cfg, monitor) => {
+  const rabbitManager = new RabbitManager(cfg.rabbit);
+  const firstNamespace = 'demo_one';
+  const secondNamespace = 'demo_two';
+  const firstDemoMessageQueue = `taskcluster/${firstNamespace}`;
+  const secondDemoMessageQueue = `taskcluster/${secondNamespace}`;
+  await rabbitManager.createQueue(firstDemoMessageQueue);
+  await rabbitManager.createQueue(secondDemoMessageQueue);
+
+  const namespaces = await load('Namespaces', {profile: 'test', process: 'test'});
+  await namespaces.ensureTable();
+
+  // TODO: Customize the payload fields
+  await monitor.pulse.createNamespace(firstNamespace, {
+    contact: {
+      method: 'email',
+      payload: {
+        address: 'a@a.com',
+        subject: 'subject',
+        content: 'content',
+      },
+    },
+  });
+  await monitor.pulse.createNamespace(secondNamespace, {
+    contact: {
+      method: 'irc',
+      payload: {
+        channel: '#taskcluster-test',
+        message: 'test',
+      },
+    },
+  });
+};
+
+const run = async () => {
+  const cfg = config({profile: 'test'});
+
+  const testclients = {
+    'test-client': ['*'],
+    'test-server': ['*'],
+  };
+
+  testing.fakeauth.start(testclients);
+
+  const webServer = await load('server', {profile: 'test', process: 'test'});
+
+  const baseUrl = 'http://localhost:' + webServer.address().port + '/v1';
+  const reference = api.reference({baseUrl: baseUrl});
+  const Pulse = taskcluster.createClient(reference);
+  const pulseClient = new Pulse({
+    baseUrl: baseUrl,
+    credentials: cfg.taskcluster.credentials,
+  });
+
+  const rabbitMonitor = new RabbitMonitor(
+    cfg.monitor,
+    cfg.app.amqpUrl,
+    new RabbitAlerter(cfg.alerter, cfg.taskcluster.credentials),
+    new RabbitManager(cfg.rabbit),
+    pulseClient
+  );
+
+  await setup(cfg, rabbitMonitor);
+
+  const verbose = true;
+  try {
+    await rabbitMonitor.run(verbose);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+run();

--- a/bin/rabbitstressor.js
+++ b/bin/rabbitstressor.js
@@ -16,16 +16,16 @@ class RabbitStressor {
    * @param {number} uploadRate            - Interval in milliseconds at which messages uploaded
    *                                         to the target queue.
    * @param {number} messageCount          - The number of messages to send.
-   * @param {string} amqpUrl               - The AMQP url to connect to. Eg. amqp://localhost.
    * @param {string} targetQueue           - The name of the queue where messages are uploaded to.
+   * @param {string} amqpUrl               - The AMQP url to connect to. Eg. amqp://localhost.
    * @param {RabbitManager} rabbitManager
    */
-  constructor({payloadSize, uploadRate, messageCount, amqpUrl, targetQueue}, rabbitManager) {
+  constructor({payloadSize, uploadRate, messageCount, targetQueue}, amqpUrl, rabbitManager) {
     assert(payloadSize, 'Must provide a payload size!');
     assert(uploadRate, 'Must provide a upload rate!');
     assert(messageCount, 'Must provide a number of messages to send!');
-    assert(amqpUrl, 'Must provide an AMQP URL!');
     assert(targetQueue, 'Must provide a target queue name!');
+    assert(amqpUrl, 'Must provide an AMQP URL!');
     assert(rabbitManager, 'Must provide a valid Rabbit Manager!');
     this.payloadSize = payloadSize;
     this.uploadRate = uploadRate;

--- a/bin/rabbitstressorrunner.js
+++ b/bin/rabbitstressorrunner.js
@@ -5,7 +5,7 @@ const RabbitStressor = require('./rabbitstressor');
 const run = async () => {
   const cfg = config({profile: 'test'});
   const rabbitManager = new RabbitManager(cfg.rabbit);
-  const runner = new RabbitStressor(cfg.stressor, rabbitManager);
+  const runner = new RabbitStressor(cfg.stressor, cfg.app.amqpUrl, rabbitManager);
   await runner.connect();
 
   console.log(`Sending ${runner.messageCount} messages each of size ${runner.payloadSize} to ${runner.targetQueue}...`);

--- a/config.yml
+++ b/config.yml
@@ -17,6 +17,7 @@ defaults:
     credentials:      # Load strings from environment variables
       clientId:       !env TASKCLUSTER_CLIENT_ID
       accessToken:    !env TASKCLUSTER_ACCESS_TOKEN
+    amqpUrl:          !env TASKCLUSTER_AMQP_URL
 
   server:
     publicUrl:                https://pulse.taskcluster.net
@@ -37,11 +38,9 @@ defaults:
     payloadSize:              !env STRESSOR_PAYLOAD_SIZE
     uploadRate:               !env STRESSOR_UPLOAD_RATE
     messageCount:             !env STRESSOR_MESSAGE_COUNT
-    amqpUrl:                  !env STRESSOR_AMQP_URL
     targetQueue:              !env STRESSOR_TARGET_QUEUE
 
   monitor:
-    amqpUrl:                      !env MONITOR_AMQP_URL
     refreshInterval:              !env MONITOR_REFRESH_INTERVAL
 
   alerter:
@@ -59,6 +58,7 @@ test:
     credentials:
       clientId:       'test-client'
       accessToken:    'none'
+    amqpUrl:          'amqp://localhost'
 
   rabbit:
     username: 'guest'
@@ -69,7 +69,6 @@ test:
     payloadSize: 20
     uploadRate: 50
     messageCount: 5
-    amqpUrl: 'amqp://localhost'
     targetQueue: 'stressor queue'
 
   server:
@@ -83,7 +82,6 @@ test:
     account:  "inMemory"
 
   monitor:
-    amqpUrl: 'amqp://localhost'
     refreshInterval: 1000
 
   alerter:

--- a/config.yml
+++ b/config.yml
@@ -5,7 +5,7 @@ defaults:
     exchangePrefix: v1/
     namespaceTableName: 'PulseNamespaces'
     namespacesExpirationDelay: '- 1 hour'
-    namespacesRotationDelay: '- 1 hour'
+    amqpUrl: !env TASKCLUSTER_AMQP_URL
 
   aws:
     accessKeyId:      !env AWS_ACCESS_KEY_ID
@@ -17,7 +17,6 @@ defaults:
     credentials:      # Load strings from environment variables
       clientId:       !env TASKCLUSTER_CLIENT_ID
       accessToken:    !env TASKCLUSTER_ACCESS_TOKEN
-    amqpUrl:          !env TASKCLUSTER_AMQP_URL
 
   server:
     publicUrl:                https://pulse.taskcluster.net
@@ -54,11 +53,13 @@ production:
     env:                      'production'
 
 test:
+  app:
+    amqpUrl: 'amqp://localhost'
+
   taskcluster:
     credentials:
       clientId:       'test-client'
       accessToken:    'none'
-    amqpUrl:          'amqp://localhost'
 
   rabbit:
     username: 'guest'

--- a/config.yml
+++ b/config.yml
@@ -41,6 +41,7 @@ defaults:
 
   monitor:
     refreshInterval:              !env MONITOR_REFRESH_INTERVAL
+    queuePrefix:                  !env MONITOR_QUEUE_PREFIX
 
   alerter:
     messageCountTolerance:        !env ALERTER_MESSAGE_COUNT_TOLERANCE
@@ -84,6 +85,7 @@ test:
 
   monitor:
     refreshInterval: 1000
+    queuePrefix: 'taskcluster/'
 
   alerter:
     messageCountTolerance: 10

--- a/config.yml
+++ b/config.yml
@@ -41,8 +41,12 @@ defaults:
     targetQueue:              !env STRESSOR_TARGET_QUEUE
 
   monitor:
-    amqpUrl:                  !env MONITOR_AMQP_URL
-    refreshInterval:          !env MONITOR_REFRESH_INTERVAL
+    amqpUrl:                      !env MONITOR_AMQP_URL
+    refreshInterval:              !env MONITOR_REFRESH_INTERVAL
+
+  alerter:
+    messageCountTolerance:        !env ALERTER_MESSAGE_COUNT_TOLERANCE
+    messagePublishRateTolerance:  !env ALERTER_MESSAGE_PUBLISH_RATE_TOLERANCE
 
 production:
   server:
@@ -51,12 +55,15 @@ production:
     env:                      'production'
 
 test:
-  server:
-    publicUrl:        http://localhost:60403
-    port:             60403
-    forceSSL:         false
-    trustProxy:       false
-    env:              development
+  taskcluster:
+    credentials:
+      clientId:       'test-client'
+      accessToken:    'none'
+
+  rabbit:
+    username: 'guest'
+    password: 'guest'
+    baseUrl:  'http://localhost:15672/api'
 
   stressor:
     payloadSize: 20
@@ -65,11 +72,20 @@ test:
     amqpUrl: 'amqp://localhost'
     targetQueue: 'stressor queue'
 
-  monitor:
-    amqpUrl: 'amqp://localhost'
-    refreshInterval: 1000
+  server:
+    publicUrl:        http://localhost:60403
+    port:             60403
+    forceSSL:         false
+    trustProxy:       false
+    env:              development
 
   azure:
     account:  "inMemory"
 
+  monitor:
+    amqpUrl: 'amqp://localhost'
+    refreshInterval: 1000
 
+  alerter:
+    messageCountTolerance: 10
+    messagePublishRateTolerance: 5

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "devDependencies": {
     "jsdoc": "^3.4.2",
     "jsdoc-strip-async-await": "^0.1.0",
-    "mocha": "^3.0.2"
+    "mocha": "^3.0.2",
+    "sinon": "^1.17.6"
   },
   "engines": {
     "node": "^6.0.0",

--- a/src/api.js
+++ b/src/api.js
@@ -28,15 +28,14 @@ module.exports = api;
  * Gets an overview of the rabbit cluster
  */
 api.declare({
-  method:   'get',
-  route:    '/overview',
-  name:     'overview',
-  title:    'Rabbit Overview',
-  output:   'rabbit-overview.json',
+  method:     'get',
+  route:      '/overview',
+  name:       'overview',
+  title:      'Rabbit Overview',
+  output:     'rabbit-overview.json',
+  stability:  'experimental',
   description: [
     'An overview of the Rabbit cluster',
-    '',
-    '**Warning** this api end-point is **not stable**.',
   ].join('\n'),
 }, async function(req, res) {
   res.reply(
@@ -51,15 +50,14 @@ api.declare({
  * Gets the list of exchanges in the rabbit cluster
  */
 api.declare({
-  method:   'get',
-  route:    '/exchanges',
-  name:     'exchanges',
-  title:    'Rabbit Exchanges',
-  output:   'exchanges-response.json',
+  method:     'get',
+  route:      '/exchanges',
+  name:       'exchanges',
+  title:      'Rabbit Exchanges',
+  output:     'exchanges-response.json',
+  stability:  'experimental',
   description: [
     'A list of exchanges in the rabbit cluster',
-    '',
-    '**Warning** this api end-point is **not stable**.',
   ].join('\n'),
 }, async function(req, res) {
   res.reply(
@@ -84,10 +82,9 @@ api.declare({
     ['pulse:namespace:<namespace>'],
   ],
   //todo later: deferAuth: true,
+  stability: 'experimental',
   description: [
     'Creates a namespace, given the taskcluster credentials with scopes.',
-    '',
-    '**Warning** this api end-point is **not stable**.',
   ].join('\n'),
 }, async function(req, res) {
   let {namespace} = req.params;
@@ -118,10 +115,9 @@ api.declare({
     ['pulse:namespace:<namespace>'],
   ],
   //todo later: deferAuth: true,
+  stability: 'experimental',
   description: [
     'Gets a namespace, given the taskcluster credentials with scopes.',
-    '',
-    '**Warning** this api end-point is **not stable**.',
   ].join('\n'),
 }, async function(req, res) {
   const {namespace} = req.params;

--- a/src/api.js
+++ b/src/api.js
@@ -32,7 +32,7 @@ api.declare({
   route:    '/overview',
   name:     'overview',
   title:    'Rabbit Overview',
-  output:   'rabbit-overview.json',		
+  output:   'rabbit-overview.json',
   description: [
     'An overview of the Rabbit cluster',
     '',
@@ -54,7 +54,7 @@ api.declare({
   method:   'get',
   route:    '/exchanges',
   name:     'exchanges',
-  title:    'Rabbit Exchanges',  
+  title:    'Rabbit Exchanges',
   output:   'exchanges-response.json',
   description: [
     'A list of exchanges in the rabbit cluster',
@@ -62,8 +62,8 @@ api.declare({
     '**Warning** this api end-point is **not stable**.',
   ].join('\n'),
 }, async function(req, res) {
-  res.reply( 
-    _.map( 
+  res.reply(
+    _.map(
       await this.rabbit.exchanges(),
       elem => _.pick(elem, ['name', 'vhost', 'type', 'durable', 'auto_delete', 'internal', 'arguments'])
     )
@@ -76,8 +76,8 @@ api.declare({
 api.declare({
   method:   'post',
   route:    '/namespace/:namespace',
-  name:     'namespace',
-  title:    'Create a namespace',	
+  name:     'createNamespace',
+  title:    'Create a namespace',
   input:    'namespace-request.json',
   output:   'namespace-response.json',
   scopes:   [
@@ -93,15 +93,10 @@ api.declare({
   let {namespace} = req.params;
   let contact = req.body.contact; //the contact information
 
-  if (namespace.length>64 || !/^[A-Za-z0-9_-]+$/.test(namespace)) {
-    return res.status(400).json({
-      message: 'Namespace provided must be at most 64 bytes and contain only these characters: [A-Za-z0-9_-]',
-      error: {
-        namespace:  req.params.namespace,
-      },
-    });
+  if (!isNamespaceValid(namespace)) {
+    return invalidNamespaceResponse(req, res);
   }
- 
+
   let newNamespace = await setNamespace(this, namespace, contact);
   res.reply({
     namespace:  newNamespace.namespace,
@@ -111,12 +106,68 @@ api.declare({
   });
 });
 
-/* 
+/**
+ * Gets namespace details
+ */
+api.declare({
+  method:   'get',
+  route:    '/namespace/:namespace',
+  name:     'namespace',
+  title:    'Get namespace information',
+  scopes:   [
+    ['pulse:namespace:<namespace>'],
+  ],
+  //todo later: deferAuth: true,
+  description: [
+    'Gets a namespace, given the taskcluster credentials with scopes.',
+    '',
+    '**Warning** this api end-point is **not stable**.',
+  ].join('\n'),
+}, async function(req, res) {
+  const {namespace} = req.params;
+
+  if (!isNamespaceValid(namespace)) {
+    return invalidNamespaceResponse(req, res);
+  }
+
+  try {
+    const namespaceResponse = await this.Namespaces.load({namespace: namespace});
+    res.reply(namespaceResponse);
+  } catch (error) {
+    return res.status(404).json({
+      message: `Could not find namespace ${namespace}`,
+    });
+  }
+});
+
+/**
+ * @param {Object} request      - An HTTP request object.
+ * @param {Object} response     - An HTTP response object.
+ * @returns {Object} A 400 error indicating that the namespace was invalid.
+ */
+function invalidNamespaceResponse(request, response) {
+  return response.status(400).json({
+    message: 'Namespace provided must be at most 64 bytes and contain only these characters: [A-Za-z-0-9_-]',
+    error: {
+      namespace:  request.params.namespace,
+    },
+  });
+}
+
+/**
+ * @param {string} namespace
+ * @returns {Boolean} True if namespace is valid.
+ */
+function isNamespaceValid(namespace) {
+  return namespace.length <= 64 && /^[A-Za-z0-9_-]+$/.test(namespace);
+}
+
+/*
  * Attempt to create a new namespace entry and associated Rabbit user.
  * If the requested namespace exists, return it.
  */
 async function setNamespace(context, namespace, contact) {
-  let newNamespace; 
+  let newNamespace;
   try {
     newNamespace = await context.Namespaces.create({
       namespace:  namespace,
@@ -128,10 +179,10 @@ async function setNamespace(context, namespace, contact) {
       nextRotation: taskcluster.fromNow('1 hour'),
       contact:    contact,
     });
-    
+
     await context.rabbit.createUser(namespace.concat('-1'), newNamespace.password, ['taskcluster-pulse']);
     await context.rabbit.createUser(namespace.concat('-2'), newNamespace.password, ['taskcluster-pulse']);
-    
+
     //set up user pairs in rabbitmq, both users are used for auth rotations
     await context.rabbit.setUserPermissions(
       namespace.concat('-1'),                                         //username
@@ -139,7 +190,7 @@ async function setNamespace(context, namespace, contact) {
       `^taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //configure pattern
       `^taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //write pattern
       '^taskcluster/exchanges/.*'                                      //read pattern
-      ); 
+      );
 
     await context.rabbit.setUserPermissions(
       namespace.concat('-2'),                                         //username
@@ -147,13 +198,13 @@ async function setNamespace(context, namespace, contact) {
       `^taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //configure pattern
       `^taskcluster/(exchanges|queues)/${newNamespace.namespace}/.*`,  //write pattern
       '^taskcluster/exchanges/.*'                                      //read pattern
-      );   
-    
+      );
+
   } catch (err) {
     if (err.code !== 'EntityAlreadyExists') {
       throw err;
     }
     newNamespace = await context.Namespaces.load({namespace: namespace});
-  } 
+  }
   return newNamespace;
 }

--- a/src/rabbitalerter.js
+++ b/src/rabbitalerter.js
@@ -55,12 +55,12 @@ class RabbitAlerter {
 
   /**
    * @param {RabbitMonitor.Stats} stats
-   * @param {Object} namespace            - Determines which kind of alert to create.
-   * @returns {RabbitAlerter.Alert}       - An alert variant.
+   * @param {Object} namespaceResponse            - Determines which kind of alert to create.
+   * @returns {RabbitAlerter.Alert}               - An alert variant.
    */
-  createAlert(stats, namespace) {
-    const contactMethod = namespace.contact.method;
-    const payload = namespace.contact.payload;
+  createAlert(stats, namespaceResponse) {
+    const contactMethod = namespaceResponse.contact.method;
+    const payload = namespaceResponse.contact.payload;
     switch (contactMethod) {
       case 'pulse':
         return new RabbitAlerter.PulseAlert(stats, this.notifier, payload.routingKey);
@@ -69,7 +69,7 @@ class RabbitAlerter {
       case 'irc':
         return new RabbitAlerter.IRCAlert(stats, this.notifier, payload.channel);
       default:
-        let warning = 'Cannot identify contact method in namespace.\n';
+        let warning = 'Cannot identify contact method in the namespace response.\n';
         warning += 'Currently supported methods are: "pulse", "email", and "irc"';
         console.warn(warning);
     }
@@ -79,13 +79,14 @@ class RabbitAlerter {
    * Sends an alert given the provided stats
    *
    * @param {RabbitMonitor.Stats} stats
+   * @param {Object} namespaceResponse   - This is where contact information is extracted from
    */
-  // TODO: The namespace response should be fetched from the pulse api
-  sendAlert(stats, namespace) {
+  async sendAlert(stats, namespaceResponse) {
     if (!this.anyTolearanceExceeded(stats)) {
       return;
     }
-    const alert = this.createAlert(stats, namespace);
+
+    const alert = this.createAlert(stats, namespaceResponse);
     if (alert !== undefined) {
       if (this.messagesExceeded(stats)) {
         alert.messagesExceeded();

--- a/src/rabbitalerter.js
+++ b/src/rabbitalerter.js
@@ -1,0 +1,205 @@
+/**
+ * An alerting system for message queues.
+ * @module rabbitalerter
+ */
+const assert = require('assert');
+const taskcluster = require('taskcluster-client');
+
+/**
+ * An interface used to generate various TaskCluster Notifications.
+ *
+ * @class RabbitAlerter
+ */
+class RabbitAlerter {
+  /**
+   * @param {number} config.alerter.messageCountTolerance       - When a queue holds more messages
+   *                                                              than this tolerance, an alert will be created.
+   * @param {number} config.alerter.messagePublishRateTolerance - When the number of messages published per second
+   *                                                              exceed this tolerance, an alert will be created.
+   * @param {Object} credentials                                - TaskCluster credentials.
+   */
+  constructor({messageCountTolerance, messagePublishRateTolerance}, credentials) {
+    assert(messageCountTolerance, 'Must provide a message count tolerance!');
+    assert(messagePublishRateTolerance, 'Must provide a message publish rate tolerance!');
+    assert(credentials.clientId, 'TaskCluster credentials requires a clientId!');
+    assert(credentials.accessToken, 'TaskCluster credentials requires an accessToken!');
+    this.notifier = new taskcluster.Notify({credentials});
+    this.messageCountTolerance = messageCountTolerance;
+    this.messagePublishRateTolerance = messagePublishRateTolerance;
+  }
+
+  /**
+   * @param {RabbitMonitor.Stats} stats
+   * @return {Boolean}
+   */
+  anyTolearanceExceeded(stats) {
+    return this.messagesExceeded(stats) || this.messagePublishRateExceeded(stats);
+  }
+
+  /**
+   * @param {RabbitMonitor.Stats} stats
+   * @return {Boolean}
+   */
+  messagesExceeded(stats) {
+    return stats.messages > this.messageCountTolerance;
+  }
+
+  /**
+   * @param {RabbitMonitor.Stats} stats
+   * @return {Boolean}
+   */
+  messagePublishRateExceeded(stats) {
+    return stats.rate > this.messagePublishRateTolerance;
+  }
+
+  /**
+   * @param {RabbitMonitor.Stats} stats
+   * @param {Object} namespace            - Determines which kind of alert to create.
+   * @returns {RabbitAlerter.Alert}                     - An alert variant.
+   */
+  createAlert(stats, namespace) {
+    const contactMethod = namespace.contact.method;
+    const payload = namespace.contact.payload;
+    switch (contactMethod) {
+      case 'pulse':
+        return new RabbitAlerter.PulseAlert(stats, this.notifier, payload.routingKey);
+      case 'email':
+        return new RabbitAlerter.EmailAlert(stats, this.notifier, payload.address);
+      case 'irc':
+        return new RabbitAlerter.IRCAlert(stats, this.notifier, payload.channel);
+      default:
+        let warning = 'Cannot identify contact method in namespace.\n';
+        warning += 'Currently supported methods are: "pulse", "email", and "irc"';
+        console.warn(warning);
+    }
+  }
+
+  /**
+   * Sends an alert given the provided stats
+   *
+   * @param {RabbitMonitor.Stats} stats
+   * @param {Object} namespace          - The namespace holding information relevant to
+   *                                      the notification method.
+   */
+  sendAlert(stats, namespace) {
+    const alert = this.createAlert(stats, namespace);
+    if (alert !== undefined) {
+      if (this.messagesExceeded(stats)) {
+        alert.messagesExceeded();
+      }
+      if (this.messagePublishRateExceeded(stats)) {
+        alert.messagePublishRateExceeded();
+      }
+      alert.notify();
+    }
+  }
+};
+
+/**
+ * A generic template for creating different alert variants.
+ *
+ * @class Alert
+ */
+RabbitAlerter.Alert = class {
+  /**
+   * Reference on the payloads for various alerts:
+   * https://github.com/taskcluster/taskcluster-notify/blob/master/test/api_test.js
+   *
+   * @param {RabbitMonitor.Stats} stats
+   * @param {Object} notifier           - TaskCluter Notifier Client.
+   */
+  constructor(stats, notifier) {
+    assert(this.notify, 'Alert.notify needs to be overridden!');
+    this.payload = {};
+    this.stats = stats;
+    this.notifier = notifier;
+  }
+
+  messagesExceeded() {
+    if (this.payload.message) {
+      this.payload.message += `- Message Count: ${stats.messages} `;
+      this.payload.message += `exceeds the tolerance of ${this.messageCountTolerance}\n`;
+    }
+  }
+
+  messagePublishRateExceeded() {
+    if (this.payload.message) {
+      this.payload.message += `- Message Publish Rate: ${stats.rate} `;
+      this.payload.message += `exceeds the tolerance of ${this.messagePublishRateTolerance}\n`;
+    }
+  }
+};
+
+/** @class PulseAlert */
+RabbitAlerter.PulseAlert = class extends RabbitAlerter.Alert {
+  /**
+   * @param {RabbitMonitor.Stats} stats
+   * @param {string} routingKey
+   */
+  constructor(stats, notifier, routingKey) {
+    super(stats, notifier);
+    this.payload.routingKey = routingKey;
+    this.payload.message = 'Alert from TaskCluster-Pulse:\n';
+    this.payload.message += `The queue ${stats.queueName} has exceeded the following thresholds:\n`;
+    this.stats = stats;
+  }
+
+  /** @override */
+  async notify() {
+    this.notifier.pulse(this.payload);
+  }
+};
+
+/** @class EmailAlert */
+RabbitAlerter.EmailAlert  = class extends RabbitAlerter.Alert {
+  /**
+   * @param {RabbitMonitor.Stats} stats
+   * @param {string} address             - An email address.
+   */
+  constructor(stats, notifier, address) {
+    super(stats, notifier);
+    this.payload = {};
+    this.payload.address = address;
+    this.payload.subject = 'TaskCluster-Pulse alert: ${stats.queueName}';
+    this.payload.content = 'Alert from TaskCluster-Pulse:\n';
+    this.payload.content += `The queue *${stats.queueName}* has exceeded the following thresholds:\n`;
+  }
+
+ /** @override */
+  messagesExceeded(stats) {
+    this.payload.content += `* Message Count: *${stats.messages}* exceeds `;
+    this.payload.content += `the tolerance of *${this.messageCountTolerance}*\n`;
+  }
+
+  /** @override */
+  messagePublishRateExceeded(stats) {
+    this.payload.content += `* Message Publish Rate: ${stats.rate} exceeds `;
+    this.payload.content += `the tolerance of ${this.messagePublishRateTolerance}\n`;
+  }
+
+  /** @override */
+  async notify() {
+    this.notifier.email(this.payload);
+  }
+};
+
+/** @class IRCAlert */
+RabbitAlerter.IRCAlert = class extends RabbitAlerter.Alert {
+  /**
+   * @param {RabbitMonitor.Stats} stats
+   * @param {string} channel            - IRC channel.
+   */
+  constructor(stats, notifier, channel) {
+    super(stats, notifier);
+    this.payload.channel = channel;
+    this.payload.message = 'Alert from TaskCluster-Pulse:\n';
+    this.payload.message += `The queue ${stats.queueName} has exceeded the following thresholds:\n`;
+  }
+
+  /** @override */
+  async notify() {
+    this.notifier.irc(this.payload);
+  }
+};
+
+module.exports = RabbitAlerter;

--- a/src/rabbitmonitor.js
+++ b/src/rabbitmonitor.js
@@ -20,16 +20,19 @@ class RabbitMonitor {
    * @param {string} config.taskcluster.amqpUrl     - The AMQP url to connect to. Eg. amqp://localhost.
    * @param {RabbitAlerter} rabbitAlerter           - Sends alerts based off various message queue statistics.
    * @param {RabbitManager} rabbitManager           - RabbitMQ client.
+   * @param {TaskClusterClient} pulse               - TaskCluster Pulse client.
    */
-  constructor({refreshInterval}, amqpUrl, rabbitAlerter, rabbitManager) {
+  constructor({refreshInterval}, amqpUrl, rabbitAlerter, rabbitManager, pulse) {
     assert(refreshInterval, 'Must provide an interval to monitor the queues!');
     assert(amqpUrl, 'Must provide an AMQP URL!');
     assert(rabbitAlerter, 'Must provide a rabbit alerter!');
     assert(rabbitManager, 'Must provide a rabbit manager!');
+    assert(pulse, 'Must provide a TaskCluster Pulse client!');
     this.amqpUrl = amqpUrl;
     this.refreshInterval = refreshInterval;
     this.rabbitManager = rabbitManager;
     this.rabbitAlerter = rabbitAlerter;
+    this.pulse = pulse;
   }
 
   /**
@@ -121,8 +124,13 @@ class RabbitMonitor {
   /**
    * @param {Array.<RabbitMonitor.Stats>} stats
    */
-  sendAlerts(stats) {
-    stats.forEach(currentStats => this.rabbitAlerter.sendAlert(currentStats));
+  async sendAlerts(stats) {
+    console.log(Object.getOwnPropertyNames(this.pulse));
+    /*
+    const promises = stats.map(currentStats => this.pulse.Namespaces.load({namespace: currentStats.queueName}));
+    const namespaceResponses = await Promise.all(promises);
+    namespaceResponses.forEach(namespaceResponse => this.rabbitAlerter.sendAlert(currentStats, namespaceResponse));
+    */
   }
 }
 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -60,8 +60,44 @@ suite('API', () => {
     });
   });
 
-  test('namespace - char limit under', () => {
-    return helper.pulse.namespace('samplenamespace', {
+  test('namespace', async () => {
+    const namespace = 'foobar';
+    const namespaceInfo = {
+      contact: {
+        method: 'email',
+        payload: {
+          address: 'a@a.com',
+          subject: 'subject',
+          content: 'content',
+        },
+      },
+    };
+    await helper.pulse.createNamespace(namespace, namespaceInfo);
+    await helper.pulse.namespace(namespace);
+  });
+
+  test('namespaceNotFound', async () => {
+    const namespace = 'foobar';
+    try {
+      await helper.pulse.namespace(namespace);
+      assert(false, 'Should have thrown a 404 error.');
+    } catch (error) {
+      assert(error.statusCode === 404);
+    }
+  });
+
+  test('invalidNamespace', async () => {
+    const namespace = 'sample%namespace';
+    try {
+      await helper.pulse.namespace(namespace);
+      assert(false, 'Should have thrown a 400 error.');
+    } catch (error) {
+      assert(error.statusCode === 400);
+    }
+  });
+
+  test('createNamespace - char limit under', () => {
+    return helper.pulse.createNamespace('samplenamespace', {
       contact: {
         method: 'email',
         payload: {address: 'a@a.com'},
@@ -69,8 +105,8 @@ suite('API', () => {
     });
   });
 
-  test('namespace - char limit over', () => {
-    return helper.pulse.namespace('samplenamespacesamplenamespacesamplenamespacesamplenamespacesamplenamespace', {
+  test('createNamespace - char limit over', () => {
+    return helper.pulse.createNamespace('samplenamespacesamplenamespacesamplenamespacesamplenamespacesamplenamespace', {
       contact: {
         method: 'email',
         payload: {address: 'a@a.com'},
@@ -82,8 +118,8 @@ suite('API', () => {
     });
   });
 
-  test('namespace - char invalid symbols', () => {
-    return helper.pulse.namespace('sample%namespace', {
+  test('createNamespace - char invalid symbols', () => {
+    return helper.pulse.createNamespace('sample%namespace', {
       contact: {
         method: 'email',
         payload: {address: 'a@a.com'},
@@ -215,13 +251,13 @@ suite('API', () => {
   });
 
   test('"namespace" idempotency - return same namespace', async () => {
-    let a = await helper.pulse.namespace('testname', {
+    let a = await helper.pulse.createNamespace('testname', {
       contact: {
         method: 'email',
         payload: {address: 'a@a.com'},
       },
     });
-    let b = await helper.pulse.namespace('testname', {
+    let b = await helper.pulse.createNamespace('testname', {
       contact: {
         method: 'email',
         payload: {address: 'a@a.com'},
@@ -232,7 +268,7 @@ suite('API', () => {
 
   test('"namespace" idempotency - entry creation', async () => {
     for (let i = 0; i < 10; i++) {
-      await helper.pulse.namespace('testname', {
+      await helper.pulse.createNamespace('testname', {
         contact: {
           method: 'email',
           payload: {address: 'a@a.com'},
@@ -254,7 +290,7 @@ suite('API', () => {
     let count = 0;
     await namespaces.scan({},
       {
-        limit:            250, 
+        limit:            250,
         handler:          (ns) => {
           count++;
         },
@@ -265,7 +301,7 @@ suite('API', () => {
 
   test('rotate namespace - one entry', async () => {
     var old_pass = slugid.v4();
-    
+
     await namespaces.create({
       namespace: 'testname',
       username: 'testname',
@@ -288,7 +324,7 @@ suite('API', () => {
 
   test('rotate namespace - two entry', async () => {
     var old_pass = slugid.v4();
-    
+
     await namespaces.create({
       namespace: 'testname1',
       username: 'testname',
@@ -327,7 +363,7 @@ suite('API', () => {
 
   test('rotate namespace - one of two entry', async () => {
     var old_pass = slugid.v4();
-    
+
     await namespaces.create({
       namespace: 'testname1',
       username: 'testname',

--- a/test/api_test.js.orig
+++ b/test/api_test.js.orig
@@ -33,8 +33,13 @@ suite('API', () => {
     return helper.pulse.exchanges();
   });
 
+<<<<<<< a4774ac9fd5b39746e69512d2370bc7e965a179c
   test('namespace - email', () => {
+    return helper.pulse.namespace('samplenamespace', {
+=======
+  test('createNamespace', () => {
     return helper.pulse.createNamespace('samplenamespace', {
+>>>>>>> Get namespace repsonses from API
       contact: {
         method: 'email',
         payload: {address: 'a@a.com'},
@@ -43,7 +48,7 @@ suite('API', () => {
   });
 
   test('namespace - irc(user)', () => {
-    return helper.pulse.createNamespace('samplenamespace', {
+    return helper.pulse.namespace('samplenamespace', {
       contact: {
         method: 'irc',
         payload: {user: 'test'},
@@ -52,7 +57,7 @@ suite('API', () => {
   });
 
   test('namespace - irc(channel)', () => {
-    return helper.pulse.createNamespace('samplenamespace', {
+    return helper.pulse.namespace('samplenamespace', {
       contact: {
         method: 'irc',
         payload: {channel: '#test'},
@@ -64,8 +69,12 @@ suite('API', () => {
     const namespace = 'foobar';
     const namespaceInfo = {
       contact: {
-        method: 'irc',
-        payload: {channel: '#test'},
+        method: 'email',
+        payload: {
+          address: 'a@a.com',
+          subject: 'subject',
+          content: 'content',
+        },
       },
     };
     await helper.pulse.createNamespace(namespace, namespaceInfo);
@@ -286,7 +295,7 @@ suite('API', () => {
     let count = 0;
     await namespaces.scan({},
       {
-        limit:            250,
+        limit:            250, 
         handler:          (ns) => {
           count++;
         },
@@ -297,7 +306,7 @@ suite('API', () => {
 
   test('rotate namespace - one entry', async () => {
     var old_pass = slugid.v4();
-
+    
     await namespaces.create({
       namespace: 'testname',
       username: 'testname',
@@ -320,7 +329,7 @@ suite('API', () => {
 
   test('rotate namespace - two entry', async () => {
     var old_pass = slugid.v4();
-
+    
     await namespaces.create({
       namespace: 'testname1',
       username: 'testname',
@@ -359,7 +368,7 @@ suite('API', () => {
 
   test('rotate namespace - one of two entry', async () => {
     var old_pass = slugid.v4();
-
+    
     await namespaces.create({
       namespace: 'testname1',
       username: 'testname',

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,5 +1,4 @@
 let assert      = require('assert');
-let Promise     = require('promise');
 let path        = require('path');
 let _           = require('lodash');
 let mocha       = require('mocha');

--- a/test/helper.js
+++ b/test/helper.js
@@ -44,10 +44,11 @@ mocha.before(async () => {
   });
 
   helper.rabbit = new Rabbit(cfg.rabbit);
-  helper.stressor = new Stressor(cfg.stressor, new Rabbit(cfg.rabbit));
+  helper.stressor = new Stressor(cfg.stressor, cfg.taskcluster.amqpUrl, new Rabbit(cfg.rabbit));
   helper.alerter = new Alerter(cfg.alerter, cfg.taskcluster.credentials);
   helper.monitor = new Monitor(
     cfg.monitor,
+    cfg.taskcluster.amqpUrl,
     new Alerter(cfg.alerter, cfg.taskcluster.credentials),
     new Rabbit(cfg.rabbit)
   );

--- a/test/helper.js
+++ b/test/helper.js
@@ -44,13 +44,14 @@ mocha.before(async () => {
   });
 
   helper.rabbit = new Rabbit(cfg.rabbit);
-  helper.stressor = new Stressor(cfg.stressor, cfg.taskcluster.amqpUrl, new Rabbit(cfg.rabbit));
+  helper.stressor = new Stressor(cfg.stressor, cfg.app.amqpUrl, new Rabbit(cfg.rabbit));
   helper.alerter = new Alerter(cfg.alerter, cfg.taskcluster.credentials);
   helper.monitor = new Monitor(
     cfg.monitor,
-    cfg.taskcluster.amqpUrl,
+    cfg.app.amqpUrl,
     new Alerter(cfg.alerter, cfg.taskcluster.credentials),
-    new Rabbit(cfg.rabbit)
+    new Rabbit(cfg.rabbit),
+    helper.pulse
   );
 });
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -11,6 +11,7 @@ let api         = require('../lib/api');
 let load        = require('../lib/main');
 let Rabbit      = require('../lib/rabbitmanager');
 let Monitor     = require('../lib/rabbitmonitor');
+let Alerter     = require('../lib/rabbitalerter');
 let data        = require('../lib/data');
 
 // Load configuration
@@ -39,15 +40,17 @@ mocha.before(async () => {
   helper.Pulse = taskcluster.createClient(reference);
   helper.pulse = new helper.Pulse({
     baseUrl: helper.baseUrl,
-    credentials: {
-      clientId:       'test-client',
-      accessToken:    'none',
-    },
+    credentials: cfg.taskcluster.credentials,
   });
 
   helper.rabbit = new Rabbit(cfg.rabbit);
   helper.stressor = new Stressor(cfg.stressor, new Rabbit(cfg.rabbit));
-  helper.monitor = new Monitor(cfg.monitor, new Rabbit(cfg.rabbit));
+  helper.alerter = new Alerter(cfg.alerter, cfg.taskcluster.credentials);
+  helper.monitor = new Monitor(
+    cfg.monitor,
+    new Alerter(cfg.alerter, cfg.taskcluster.credentials),
+    new Rabbit(cfg.rabbit)
+  );
 });
 
 mocha.after(async () => {

--- a/test/rabbit_alerter_test.js
+++ b/test/rabbit_alerter_test.js
@@ -17,7 +17,7 @@ suite('Rabbit Alerter', () => {
     return new RabbitMonitor.Stats(queueName, messages, rate);
   };
 
-  const createEmptyNamespace = () => {
+  const createEmptyNamespaceResponse = () => {
     return {
       contact: {
         method: '',
@@ -48,12 +48,12 @@ suite('Rabbit Alerter', () => {
 
   test('createPulseAlert', () => {
     const stats = createStats();
-    const namespace = createEmptyNamespace();
+    const namespaceResponse = createEmptyNamespaceResponse();
 
-    namespace.contact.method = 'pulse';
-    namespace.contact.payload.routingKey = 'rabbit-alerter-test';
+    namespaceResponse.contact.method = 'pulse';
+    namespaceResponse.contact.payload.routingKey = 'rabbit-alerter-test';
 
-    const pulseAlert = helper.alerter.createAlert(stats, namespace);
+    const pulseAlert = helper.alerter.createAlert(stats, namespaceResponse);
     assert(_.has(pulseAlert, 'payload'));
     assert(_.has(pulseAlert.payload, 'routingKey'));
     assert(_.has(pulseAlert.payload, 'message'));
@@ -61,12 +61,12 @@ suite('Rabbit Alerter', () => {
 
   test('createEmailAlert', () => {
     const stats = createStats();
-    const namespace = createEmptyNamespace();
+    const namespaceResponse = createEmptyNamespaceResponse();
 
-    namespace.contact.method = 'email';
-    namespace.contact.payload.address = 'alert@pulsetests.com';
+    namespaceResponse.contact.method = 'email';
+    namespaceResponse.contact.payload.address = 'alert@pulsetests.com';
 
-    const emailAlert = helper.alerter.createAlert(stats, namespace);
+    const emailAlert = helper.alerter.createAlert(stats, namespaceResponse);
     assert(_.has(emailAlert, 'payload'));
     assert(_.has(emailAlert.payload, 'address'));
     assert(_.has(emailAlert.payload, 'subject'));
@@ -76,12 +76,12 @@ suite('Rabbit Alerter', () => {
 
   test('createIRCAlert', () => {
     const stats = createStats();
-    const namespace = createEmptyNamespace();
+    const namespaceResponse = createEmptyNamespaceResponse();
 
-    namespace.contact.method = 'irc';
-    namespace.contact.payload.channel = '#taskcluster-test';
+    namespaceResponse.contact.method = 'irc';
+    namespaceResponse.contact.payload.channel = '#taskcluster-test';
 
-    const pulseAlert = helper.alerter.createAlert(stats, namespace);
+    const pulseAlert = helper.alerter.createAlert(stats, namespaceResponse);
     assert(_.has(pulseAlert, 'payload'));
     assert(_.has(pulseAlert.payload, 'channel'));
     assert(_.has(pulseAlert.payload, 'message'));
@@ -96,33 +96,33 @@ suite('Rabbit Alerter', () => {
     helper.alerter.notifier = mockNotifier;
 
     const stats = createStats();
-    const namespace = createEmptyNamespace();
+    const namespaceResponse = createEmptyNamespaceResponse();
 
-    namespace.contact.method = 'pulse';
-    helper.alerter.sendAlert(stats, namespace);
+    namespaceResponse.contact.method = 'pulse';
+    helper.alerter.sendAlert(stats, namespaceResponse);
     assert(!mockNotifier.pulse.called);
 
-    namespace.contact.method = 'email';
-    helper.alerter.sendAlert(stats, namespace);
+    namespaceResponse.contact.method = 'email';
+    helper.alerter.sendAlert(stats, namespaceResponse);
     assert(!mockNotifier.email.called);
 
-    namespace.contact.method = 'irc';
-    helper.alerter.sendAlert(stats, namespace);
+    namespaceResponse.contact.method = 'irc';
+    helper.alerter.sendAlert(stats, namespaceResponse);
     assert(!mockNotifier.irc.called);
 
     // This should exceed at leat one of the tolerances,
     // giving the alerter a better purpose to deliver alerts.
     stats.messages = 100;
-    namespace.contact.method = 'pulse';
-    helper.alerter.sendAlert(stats, namespace);
+    namespaceResponse.contact.method = 'pulse';
+    helper.alerter.sendAlert(stats, namespaceResponse);
     assert(mockNotifier.pulse.calledOnce);
 
-    namespace.contact.method = 'email';
-    helper.alerter.sendAlert(stats, namespace);
+    namespaceResponse.contact.method = 'email';
+    helper.alerter.sendAlert(stats, namespaceResponse);
     assert(mockNotifier.email.calledOnce);
 
-    namespace.contact.method = 'irc';
-    helper.alerter.sendAlert(stats, namespace);
+    namespaceResponse.contact.method = 'irc';
+    helper.alerter.sendAlert(stats, namespaceResponse);
     assert(mockNotifier.irc.calledOnce);
   });
 });

--- a/test/rabbit_alerter_test.js
+++ b/test/rabbit_alerter_test.js
@@ -1,0 +1,113 @@
+suite('Rabbit Alerter', () => {
+  const assert = require('assert');
+  const sinon = require('sinon');
+  const _ = require('lodash');
+  const helper = require('./helper');
+  const RabbitMonitor = require('../lib/rabbitmonitor');
+
+  const queueOne = 'one';
+  const queueTwo = 'two';
+  const taskClusterQueueOne = 'taskcluster/one';
+  const taskClusterQueueTwo = 'taskcluster/two';
+
+  const createStats = () => {
+    const queueName = taskClusterQueueOne;
+    const messages = 0;
+    const rate = 0;
+    return new RabbitMonitor.Stats(queueName, messages, rate);
+  };
+
+  const createEmptyNamespace = () => {
+    return {
+      contact: {
+        method: '',
+        payload: { },
+      },
+    };
+  };
+
+  test('messagesExceeded', () => {
+    const stats = createStats();
+
+    stats.messages = 20;
+    assert(helper.alerter.messagesExceeded(stats));
+
+    stats.messages = 10;
+    assert(!helper.alerter.messagesExceeded(stats));
+  });
+
+  test('messagePublishRateExceeded', () => {
+    const stats = createStats();
+
+    stats.rate = 20;
+    assert(helper.alerter.messagePublishRateExceeded(stats));
+
+    stats.rate = 0;
+    assert(!helper.alerter.messagePublishRateExceeded(stats));
+  });
+
+  test('createPulseAlert', () => {
+    const stats = createStats();
+    const namespace = createEmptyNamespace();
+
+    namespace.contact.method = 'pulse';
+    namespace.contact.payload.routingKey = 'rabbit-alerter-test';
+
+    const pulseAlert = helper.alerter.createAlert(stats, namespace);
+    assert(_.has(pulseAlert, 'payload'));
+    assert(_.has(pulseAlert.payload, 'routingKey'));
+    assert(_.has(pulseAlert.payload, 'message'));
+  });
+
+  test('createEmailAlert', () => {
+    const stats = createStats();
+    const namespace = createEmptyNamespace();
+
+    namespace.contact.method = 'email';
+    namespace.contact.payload.address = 'alert@pulsetests.com';
+
+    const emailAlert = helper.alerter.createAlert(stats, namespace);
+    assert(_.has(emailAlert, 'payload'));
+    assert(_.has(emailAlert.payload, 'address'));
+    assert(_.has(emailAlert.payload, 'subject'));
+    assert(_.has(emailAlert.payload, 'content'));
+    assert(!_.has(emailAlert.payload, 'message'));
+  });
+
+  test('createIRCAlert', () => {
+    const stats = createStats();
+    const namespace = createEmptyNamespace();
+
+    namespace.contact.method = 'irc';
+    namespace.contact.payload.channel = '#taskcluster-test';
+
+    const pulseAlert = helper.alerter.createAlert(stats, namespace);
+    assert(_.has(pulseAlert, 'payload'));
+    assert(_.has(pulseAlert.payload, 'channel'));
+    assert(_.has(pulseAlert.payload, 'message'));
+  });
+
+  test('sendAlert', async () => {
+    const mockNotifier = {
+      pulse: sinon.spy(),
+      email: sinon.spy(),
+      irc: sinon.spy(),
+    };
+    helper.alerter.notifier = mockNotifier;
+
+    const stats = createStats();
+    const namespace = createEmptyNamespace();
+
+    namespace.contact.method = 'pulse';
+    helper.alerter.sendAlert(stats, namespace);
+    assert(mockNotifier.pulse.calledOnce);
+
+    namespace.contact.method = 'email';
+    helper.alerter.sendAlert(stats, namespace);
+    assert(mockNotifier.email.calledOnce);
+
+    namespace.contact.method = 'irc';
+    helper.alerter.sendAlert(stats, namespace);
+    assert(mockNotifier.irc.calledOnce);
+  });
+});

--- a/test/rabbit_alerter_test.js
+++ b/test/rabbit_alerter_test.js
@@ -100,6 +100,21 @@ suite('Rabbit Alerter', () => {
 
     namespace.contact.method = 'pulse';
     helper.alerter.sendAlert(stats, namespace);
+    assert(!mockNotifier.pulse.called);
+
+    namespace.contact.method = 'email';
+    helper.alerter.sendAlert(stats, namespace);
+    assert(!mockNotifier.email.called);
+
+    namespace.contact.method = 'irc';
+    helper.alerter.sendAlert(stats, namespace);
+    assert(!mockNotifier.irc.called);
+
+    // This should exceed at leat one of the tolerances,
+    // giving the alerter a better purpose to deliver alerts.
+    stats.messages = 100;
+    namespace.contact.method = 'pulse';
+    helper.alerter.sendAlert(stats, namespace);
     assert(mockNotifier.pulse.calledOnce);
 
     namespace.contact.method = 'email';

--- a/test/rabbit_monitor_test.js
+++ b/test/rabbit_monitor_test.js
@@ -1,5 +1,6 @@
 suite('Rabbit Monitor', () => {
   const assert = require('assert');
+  const sinon = require('sinon');
   const _ = require('lodash');
   const helper = require('./helper');
 
@@ -44,20 +45,20 @@ suite('Rabbit Monitor', () => {
     const queueNames = [queueOne, queueTwo];
     const refreshTimes = 3;
     helper.monitor.refreshInterval = 50;
+    helper.monitor.collectStats = sinon.spy();
     await helper.monitor.monitorQueues(queueNames, refreshTimes);
-
-    assert(helper.monitor.stats);
-    assert(helper.monitor.stats.length === 2);
+    assert(helper.monitor.collectStats.calledThrice);
   });
 
   test('runAndStop', async () => {
+    helper.monitor.collectStats = sinon.spy();
     helper.monitor.refreshInterval = 50;
     helper.monitor.run();
 
     const afterTimeout = async (resolvePromise) => {
       assert(helper.monitor.monitoringInterval);
       helper.monitor.stop();
-      assert(helper.monitor.stats);
+      assert(helper.monitor.collectStats.calledOnce);
       assert(helper.monitor.monitoringInterval === undefined);
       resolvePromise();
     };

--- a/test/rabbit_monitor_test.js
+++ b/test/rabbit_monitor_test.js
@@ -53,7 +53,6 @@ suite('Rabbit Monitor', () => {
   });
 
   test.skip('runAndStop', async () => {
-    helper.monitor.collectStats = sinon.spy();
     helper.monitor.refreshInterval = 50;
     helper.monitor.run();
 

--- a/test/rabbit_monitor_test.js
+++ b/test/rabbit_monitor_test.js
@@ -99,20 +99,13 @@ suite('Rabbit Monitor', () => {
       await helper.monitor.pulse.createNamespace(namespaceOne, {
         contact: {
           method: 'email',
-          payload: {
-            address: 'a@a.com',
-            subject: 'subject',
-            content: 'content',
-          },
+          payload: {address: 'a@a.com'},
         },
       });
       await helper.monitor.pulse.createNamespace(namespaceTwo, {
         contact: {
           method: 'irc',
-          payload: {
-            channel: '#taskcluster-test',
-            message: 'test',
-          },
+          payload: {channel: '#taskcluster-test'},
         },
       });
       // TODO: Once the pulse contact method schema is available, test that one as well.

--- a/user-config-example.yml
+++ b/user-config-example.yml
@@ -1,6 +1,2 @@
 ---
 defaults:
-  rabbit:
-    username: 'guest'
-    password: 'guest'
-    baseUrl:  'http://localhost:15672/api'


### PR DESCRIPTION
## TL;DR
Various alerts can now be sent while monitoring RabbitMQ message queues.

## Details
The message queues will be monitored based off the configuration `MONITOR_QUEUE_PREFIX`. For example, all queues whose names start with `taskcluster/` will be monitored every `MONITOR_REFRESH_INTERVAL` (in milliseconds). More specifically, a GET request is sent out to get statistics on the target message queues every `MONITOR_REFRESH_INTERVAL` milliseconds.

We only want to send alerts for queues who exceed various thresholds. Therefore, we can set these tolerances under `config.alerter`. So far, we only monitor for the message count and message upload rate exceeding a configurable threshold as shown in `config.yml`.

Finally, the type of alert is based on a namespace response. For example:

We monitor a message queue whose name is the following: `taskcluster/one`.
The namespace will be `one`.

The table holding the namespace information is then queried using the namespace `one` as a key. This allows the Rabbit Alerter to tailor its alert based off the contact information found in the namespace response.

