### PR TITLE
Initial Vagrant setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /lib
 /.test
 /.bin
+/.vagrant
 /node_modules
 /docs/jsdoc
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,8 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "taskcluster-dev-0.2.0"
+  config.vm.box_url = "https://s3.amazonaws.com/task-cluster-dev/0.2.0/taskcluster_dev.box"
+  config.vm.provision "shell", path: 'vagrant.sh'
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,6 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "taskcluster-dev-0.2.0"
-  config.vm.box_url = "https://s3.amazonaws.com/task-cluster-dev/0.2.0/taskcluster_dev.box"
+  config.vm.box = "ubuntu/xenial64"
   config.vm.provision "shell", path: 'vagrant.sh'
 end

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
 
-# Latest LTS as of Nov 22, 2016
-NODE_VERSION="6.9.1"
+# Install required system packages:
+# python & build-essential by some npm packages, libssl-dev by nvm
+apt-get -q update
+apt-get -qy upgrade
+apt-get -qy install python build-essential libssl-dev rabbitmq-server
 
-# Install new nodejs.
-_node_filename="node-v${NODE_VERSION}-linux-x64.tar.xz"
-_node_url="https://nodejs.org/dist/v${NODE_VERSION}/${_node_filename}"
-cd /usr/local
-wget -nv "$_node_url"
-mkdir "node-${NODE_VERSION}"
-tar xf "${_node_filename}" -C "node-${NODE_VERSION}" --strip-components=1
-rm "${_node_filename}"
-# Overwrite existing nodejs PATH env.
-echo "export PATH=\$PATH:/usr/local/node-${NODE_VERSION}/bin" > /etc/profile.d/nodejs.sh
+# Install the latest LTS node (and npm) via nvm.
+# Run commands in a LOGIN shell (note the '-') to ensure correct envs and working dir.
+su - ubuntu -- <<"EOF"
+curl -so- https://raw.githubusercontent.com/creationix/nvm/v0.32.1/install.sh | bash
+# Activate nvm now.
+. ~/.nvm/nvm.sh
+nvm install --lts
+nvm alias default node
+EOF
 
 # Enable rabbitmq-management plugin.
 rabbitmq-plugins enable rabbitmq_management

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Latest LTS as of Nov 22, 2016
+NODE_VERSION="6.9.1"
+
+# Install new nodejs.
+_node_filename="node-v${NODE_VERSION}-linux-x64.tar.xz"
+_node_url="https://nodejs.org/dist/v${NODE_VERSION}/${_node_filename}"
+cd /usr/local
+wget -nv "$_node_url"
+mkdir "node-${NODE_VERSION}"
+tar xf "${_node_filename}" -C "node-${NODE_VERSION}" --strip-components=1
+rm "${_node_filename}"
+# Overwrite existing nodejs PATH env.
+echo "export PATH=\$PATH:/usr/local/node-${NODE_VERSION}/bin" > /etc/profile.d/nodejs.sh
+
+# Enable rabbitmq-management plugin.
+rabbitmq-plugins enable rabbitmq_management
+service rabbitmq-server restart


### PR DESCRIPTION
I used the `Vagrantfile` in `taskcluster-client` as an example and changed the box version to 0.2.0, which is the latest I can find on our S3 (https://s3.amazonaws.com/task-cluster-dev/).

Yet it is still too old -- Ubuntu 13.10. I worked around the node/npm version problem by updating the local node/npm, but didn't really want to mess around with rabbitmq as it was installed from the repo. Tests are currently failing inside the Vagrant box because of outdated rabbitmq (the management API has changed).

Do we have a newer template box? Or shall I just go ahead and provision from the vanilla `hashicorp/precise64` (which wouldn't need much work)?