### PR TITLE
Remove unnecessary fields from namespace creation requests

### DIFF
--- a/schemas/email-request.yml
+++ b/schemas/email-request.yml
@@ -19,42 +19,6 @@ properties:
         format:         email
         description: |
           E-mail address to which the message should be sent
-      subject:
-        type:           string
-        maxLength:      255
-        minLength:      1
-        description: |
-          Subject line of the e-mail, this is plain-text
-      content:
-        type:           string
-        minLength:      1
-        maxLength:      102400
-        description: |
-          Content of the e-mail as **markdown**, will be rendered to HTML before
-          the email is sent. Notice that markdown allows for a few HTML tags, but
-          won't allow inclusion of script tags and other unpleasantries.
-      link:
-        type: object
-        description: |
-          Optional link that can be added as a button to the email.
-        properties:
-          text:
-            type:           string
-            maxLength:      40
-            minLength:      1
-            description: |
-              Text to display on link.
-          href:
-            type:           string
-            maxLength:      1024
-            minLength:      1
-            format:         uri
-            description: |
-              Where the link should point to.
-        additionalProperties: false
-        required:
-          - text
-          - href
       replyTo:
         type:           string
         format:         email
@@ -63,8 +27,6 @@ properties:
     additionalProperties: false
     required:
       - address
-      - subject
-      - content
 additionalProperties: false
 required:
   - method

--- a/schemas/irc-request.yml
+++ b/schemas/irc-request.yml
@@ -28,16 +28,7 @@ properties:
         description: |
           User to post the message to. Please note that you **must** supply
           either `user` or `channel`, you cannot supply both.
-      message:
-        type:           string
-        minLength:      1
-        maxLength:      510
-        description: |
-          IRC message to send as plain text.
-    maxProperties: 2
     additionalProperties: false
-    required:
-      - message
     oneOf:
       - required: [channel]
       - required: [user]

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -33,15 +33,29 @@ suite('API', () => {
     return helper.pulse.exchanges();
   });
 
-  test('namespace', () => {
+  test('namespace - email', () => {
     return helper.pulse.namespace('samplenamespace', {
       contact: {
         method: 'email',
-        payload: {
-          address: 'a@a.com',
-          subject: 'subject',
-          content: 'content',
-        },
+        payload: {address: 'a@a.com'},
+      },
+    });
+  });
+
+  test('namespace - irc(user)', () => {
+    return helper.pulse.namespace('samplenamespace', {
+      contact: {
+        method: 'irc',
+        payload: {user: 'test'},
+      },
+    });
+  });
+
+  test('namespace - irc(channel)', () => {
+    return helper.pulse.namespace('samplenamespace', {
+      contact: {
+        method: 'irc',
+        payload: {channel: '#test'},
       },
     });
   });
@@ -50,11 +64,7 @@ suite('API', () => {
     return helper.pulse.namespace('samplenamespace', {
       contact: {
         method: 'email',
-        payload: {
-          address: 'a@a.com',
-          subject: 'subject',
-          content: 'content',
-        },
+        payload: {address: 'a@a.com'},
       },
     });
   });
@@ -63,11 +73,7 @@ suite('API', () => {
     return helper.pulse.namespace('samplenamespacesamplenamespacesamplenamespacesamplenamespacesamplenamespace', {
       contact: {
         method: 'email',
-        payload: {
-          address: 'a@a.com',
-          subject: 'subject',
-          content: 'content',
-        },
+        payload: {address: 'a@a.com'},
       },
     }).then(function() {
       assert(false, 'This shouldn\'t have worked');
@@ -80,11 +86,7 @@ suite('API', () => {
     return helper.pulse.namespace('sample%namespace', {
       contact: {
         method: 'email',
-        payload: {
-          address: 'a@a.com',
-          subject: 'subject',
-          content: 'content',
-        },
+        payload: {address: 'a@a.com'},
       },
     }).then(function() {
       assert(false, 'This shouldn\'t have worked');
@@ -216,21 +218,13 @@ suite('API', () => {
     let a = await helper.pulse.namespace('testname', {
       contact: {
         method: 'email',
-        payload: {
-          address: 'a@a.com',
-          subject: 'subject',
-          content: 'content',
-        },
+        payload: {address: 'a@a.com'},
       },
     });
     let b = await helper.pulse.namespace('testname', {
       contact: {
         method: 'email',
-        payload: {
-          address: 'a@a.com',
-          subject: 'subject',
-          content: 'content',
-        },
+        payload: {address: 'a@a.com'},
       },
     });
     assert(_.isEqual(a, b));
@@ -241,11 +235,7 @@ suite('API', () => {
       await helper.pulse.namespace('testname', {
         contact: {
           method: 'email',
-          payload: {
-            address: 'a@a.com',
-            subject: 'subject',
-            content: 'content',
-          },
+          payload: {address: 'a@a.com'},
         },
       });
     }


### PR DESCRIPTION
I'm proposing this PR following the discussing in #55 .

I take a relatively drastic approach to completely remove them instead of marking them as not required for the following rationales:

1. The removed fields are not needed and do not have any effect in foreseeable scenarios (e.g. in #50 , the alerter). We always generate the message/subject/content strings internally based on the actual alerts. Even if users of tc-pulse really wants to customize the alerts, it'd be more likely some kind of prefixes or templates.
2. If later on we need any of these fields, we can always add them back as optional fields.

Open to suggestions and comments!