### PR TITLE
Bug 1335954, part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,34 @@ Taskcluster Pulse Management Service
 [![Build Status](https://travis-ci.org/taskcluster/taskcluster-pulse.svg?branch=master)](https://travis-ci.org/taskcluster/taskcluster-pulse)
 [![License](https://img.shields.io/badge/license-MPL%202.0-orange.svg)](http://mozilla.org/MPL/2.0)
 
-A service to manage Pulse credentials for anything using
-Taskcluster credentials. This allows us self-service and
-greater control within the Taskcluster project.
+A service to manage Pulse credentials for anything using Taskcluster
+credentials. This allows us self-service and greater control within the
+Taskcluster project.
 
-Usage
------
+Operation
+---------
 
-Write this later.
+Services using pulse credentials call this service's `claimNamespace` endpoint
+to claim a "namespace" in pulse, allowing access to exchanges and queues based
+on that namespace.
 
-Options and Defaults
---------------------
+The  service must call the endpoint periodically, each time getting a fresh
+username and password to access pulse.  Access is checked each time using
+Taskcluster credentials.
 
-Write this later.
+The service monitors the existing credentials:
+
+* rotating the password on unclaimed credentials
+* notifying owners of, and eventually deleting queues which grow too large
+* deleting queues and exchanges when the corresponding namespace expires
+
+Status
+------
+
+This service is not in production yet.
+
+It does not yet connect to pulse, and the queue monitoring mentioned above is
+not yet complete.
 
 Testing
 -------

--- a/config.yml
+++ b/config.yml
@@ -9,12 +9,23 @@ defaults:
     # namespaces are rotated at this time interval.
     namespaceRotationInterval: '1 hour'
 
+    # the virtualhost to manage
+    virtualhost: /
+
+    # permissions to give to users; {{namespace}} is replaced by the namespace
+    userConfigPermission: "^(queue/{{namespace}}/.*|exchange/{{namespace}}/.*)"
+    userWritePermission: "^(queue/{{namespace}}/.*|exchange/{{namespace}}/.*)"
+    userReadPermission: "^(queue/{{namespace}}/.*|exchange/.*)"
+
+    # tags to be applied to new users
+    userTags: [taskcluster-pulse]
+
     # If given, all namespaces must begin with this string; and only
     # matching queues and exchanges will be monitored.  Use this to
-    # allow taskcluster-pulse to "share" a rabbitmq server with other
+    # allow taskcluster-pulse to "share" a rabbitmq virtualhost with other
     # users.
-    namespacePrefix: !env NAMESPACE_PREFIX
-    # TODO: add virtualHost too
+    namespacePrefix: 'taskcluster-'
+
     amqpUrl: !env TASKCLUSTER_AMQP_URL
 
   aws:

--- a/config.yml
+++ b/config.yml
@@ -66,6 +66,7 @@ test:
   app:
     amqpUrl: 'amqp://localhost'
     namespacePrefix: 'tcpulse-test-'
+    namespaceRotationInterval: '1 hour'
 
   taskcluster:
     credentials:

--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,10 @@ defaults:
     exchangePrefix: v1/
     namespaceTableName: 'PulseNamespaces'
     namespacesExpirationDelay: '- 1 hour'
+
+    # namespaces are rotated at this time interval.
+    namespaceRotationInterval: '1 hour'
+
     # If given, all namespaces must begin with this string; and only
     # matching queues and exchanges will be monitored.  Use this to
     # allow taskcluster-pulse to "share" a rabbitmq server with other

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,0 @@
----
-title: Using Taskcluster Pulse
----
-
-TODO: Write something here.

--- a/schemas/list-namespaces-response.yml
+++ b/schemas/list-namespaces-response.yml
@@ -20,6 +20,10 @@ properties:
           type:           string
           description: |
             The namespace's name
+        created:
+          description:    Date-time at which this namespace was first claimed.
+          type:           string
+          format:         date-time
         contact:
           type:           object
           title:          Contact Information

--- a/schemas/namespace-request.yml
+++ b/schemas/namespace-request.yml
@@ -4,6 +4,13 @@ description: |
   Namespace creation request
 type: object
 properties:
+  expires:
+    description: |
+      Date-time after which the username, and all associated queues and
+      exchanges, should be deleted. This can be updated on every claim, with no
+      limit. In most cases it should be set to several days in the future.
+    type:       string
+    format:     date-time
   contact:
     type:           object
     title:          Contact Information
@@ -14,4 +21,4 @@ properties:
 additionalProperties: false
 required:
   - contact
-
+  - expires

--- a/schemas/namespace-response.yml
+++ b/schemas/namespace-response.yml
@@ -8,6 +8,10 @@ properties:
     type:           string
     title:          Namespace
     description:    The name of the namespace created
+  created:
+    description:    Date-time at which this namespace was first claimed.
+    type:           string
+    format:         date-time
   username:
     type:           string
     title:          Username

--- a/schemas/namespace-response.yml
+++ b/schemas/namespace-response.yml
@@ -20,6 +20,12 @@ properties:
     type:           string
     title:          Password
     description:    The password created for authentication
+  reclaimAt:
+    description: |
+      The caller should plan to call `claimNamespace` again at this time. The provided
+      password will become invalid a short time after this.
+    type:       string
+    format:     date-time
   expires:
     description: |
       Date-time after which the username, and all associated queues and

--- a/schemas/namespace-response.yml
+++ b/schemas/namespace-response.yml
@@ -16,6 +16,12 @@ properties:
     type:           string
     title:          Password
     description:    The password created for authentication
+  expires:
+    description: |
+      Date-time after which the username, and all associated queues and
+      exchanges, should be deleted.
+    type:       string
+    format:     date-time
   contact:
     type:           object
     title:          Contact Information

--- a/src/data.js
+++ b/src/data.js
@@ -37,6 +37,7 @@ Namespace.prototype.json = function() {
     namespace: this.namespace,
     username: Namespace.getRotationUsername(this),
     password: this.password,
+    created: this.created.toJSON(),
     expires: this.expires.toJSON(),
     contact: this.contact,
   };

--- a/src/data.js
+++ b/src/data.js
@@ -3,10 +3,20 @@ let Entity = require('azure-entities');
 let taskcluster = require('taskcluster-client');
 let slugid = require('slugid');
 let RabbitManager = require('../lib/rabbitmanager');
+let _ = require('lodash');
+let Debug = require('debug');
 
 /**
  * Entity for keeping track of pulse user credentials
  *
+ * Two pulse users are defined for each namespace: "<namespace>-1" and
+ * "<namespace>-2". At any time, one of these is "active", and the other
+ * is in "standby".  The two are swapped, with the standby user's password
+ * reset, on a regular basis.
+ *
+ * Users should always be given the active username/password, and should
+ * be told to get updated credentials before the time that password is
+ * reset.
  */
 let Namespace = Entity.configure({
   version:          1,
@@ -14,38 +24,130 @@ let Namespace = Entity.configure({
   rowKey:           Entity.keys.ConstantKey('namespace'),
   properties: {
     namespace:      Entity.types.String,
-    username:       Entity.types.String,
+    // password for the active username
     password:       Entity.types.String,
+
+    // date at which this namespace was first created
     created:        Entity.types.Date,
+
+    // date at which this user, and all associated queues and exchanges,
+    // should be deleted
     expires:        Entity.types.Date,
+
+    // the currently active username suffix ("1" or "2")
     rotationState:  Entity.types.String,
+
+    // date after which the currently active user will become the standby user
+    // and the standby user will become active (with a new password). Users of
+    // the active password should renew after this time; users of the standby
+    // password must renew before this time.
     nextRotation:   Entity.types.Date,
 
-  /**
-   * Contact object with properties
-   * -method
-   * -payload
-   * 
-   * See JSON schema for documentation
-   */
+    /**
+     * Contact object with properties
+     * -method
+     * -payload
+     *
+     * See JSON schema for documentation
+     */
     contact:        Entity.types.JSON,
   },
 });
 
-Namespace.prototype.json = function() {
+Namespace.prototype.json = function(cfg) {
+  // calculate the reclaimAt as half the rotation interval past the
+  // next rotation time
+  let nextRotation = this.nextRotation;
+  let rotationAfter = taskcluster.fromNow(cfg.app.namespaceRotationInterval, nextRotation);
+  let reclaimAt = new Date(nextRotation.getTime() + (rotationAfter - nextRotation) / 2);
+
   return {
     namespace: this.namespace,
-    username: Namespace.getRotationUsername(this),
+    username: this.username(),
     password: this.password,
     created: this.created.toJSON(),
     expires: this.expires.toJSON(),
+    reclaimAt: reclaimAt.toJSON(),
     contact: this.contact,
   };
 };
 
-Namespace.getRotationUsername = function(ns) {
-  assert(ns instanceof Namespace, 'ns must be a namespace');
-  return ns.username.concat('-').concat(ns.rotationState);
+Namespace.prototype.username = function() {
+  return `${this.namespace}-${this.rotationState}`;
+};
+
+let setPulseUser = async function({username, password, namespace, rabbitManager, cfg}) {
+  await rabbitManager.createUser(username, password, ['taskcluster-pulse']);
+
+  // TODO: make these configurable too
+  await rabbitManager.setUserPermissions(
+    username,
+    '/',
+    `^taskcluster/(exchanges|queues)/${namespace}/.*`,
+    `^taskcluster/(exchanges|queues)/${namespace}/.*`,
+    '^taskcluster/exchanges/.*',
+  );
+};
+
+/*
+ * Attempt to create a new namespace entry and associated Rabbit user.
+ * If the requested namespace exists, update it with any user-supplied settnigs,
+ * and return it.
+ */
+Namespace.claim = async function({cfg, rabbitManager, namespace, contact, expires}) {
+  let newNamespace;
+  let created;
+
+  try {
+    newNamespace = await Entity.create.call(this, {
+      namespace: namespace,
+      username: namespace,
+      password: slugid.v4(),
+      created: new Date(),
+      expires,
+      rotationState:  '1',
+      nextRotation: taskcluster.fromNow(cfg.app.namespaceRotationInterval),
+      contact,
+    });
+
+    created = true;
+  } catch (err) {
+    if (err.code !== 'EntityAlreadyExists') {
+      throw err;
+    }
+
+    created = false;
+
+    // get the existing row
+    newNamespace = await Entity.load.call(this, {namespace: namespace});
+
+    // If this claim contains different information, update it accordingly
+    if (!_.isEqual(
+      {expires: newNamespace.expires, contact: newNamespace.contact},
+      {expires, contact})) {
+      await newNamespace.modify(entity => {
+        entity.expires = expires;
+        entity.contact = contact;
+      });
+
+      newNamespace = await Entity.load.call(this, {namespace: namespace});
+    }
+  }
+
+  if (created) {
+    // set up the first user as active,
+    await setPulseUser({
+      username: `${namespace}-1`,
+      password: newNamespace.password,
+      namespace, cfg, rabbitManager});
+    // ..and the second user as inactive (empty string means no logins allowed)
+    await setPulseUser({
+      username: `${namespace}-2`,
+      password: '',
+      namespace, cfg, rabbitManager});
+  }
+
+  return newNamespace;
 };
 
 Namespace.expire = async function(now) {
@@ -63,28 +165,32 @@ Namespace.expire = async function(now) {
   return count;
 };
 
-Namespace.rotate = async function(now, rabbit) {
-  assert(now instanceof Date, 'now must be given as option');
-  assert(rabbit instanceof RabbitManager, 'rabbit manager must be given as option');
-  
+Namespace.rotate = async function(now, cfg, rabbitManager) {
   let count = 0;
+  let debug = Debug('rotate');
+
   await Entity.scan.call(this, {
     nextRotation:          Entity.op.lessThan(now),
   }, {
     limit:            250, // max number of concurrent modify operations
     handler:          async (ns) => {
       count++;
-      let nextPass = slugid.v4();
-      let nextRotationState = ns.rotationState === '1' ? '2' : '1';
+      debug(`rotating ${ns.namespace}`);
+      let password = slugid.v4();
+      let rotationState = ns.rotationState === '1' ? '2' : '1';
 
-      //modify user in rabbitmq
-      await rabbit.createUser(ns.username.concat('-').concat(nextRotationState), nextPass, ['taskcluster-pulse']);
+      // modify user in rabbitmq
+      await setPulseUser({
+        username: `${ns.namespace}-${rotationState}`,
+        password,
+        namespace: ns.namespace,
+        cfg, rabbitManager});
 
-      //modify ns in table
+      // modify ns in table
       await ns.modify((entity) => {
-        entity.rotationState = nextRotationState;
-        entity.nextRotation = taskcluster.fromNow('1 hour');
-        entity.password = nextPass;
+        entity.rotationState = rotationState;
+        entity.nextRotation = taskcluster.fromNow(cfg.app.namespaceRotationInterval),
+        entity.password = password;
       });
     },
   });

--- a/src/data.js
+++ b/src/data.js
@@ -67,7 +67,6 @@ Namespace.rotate = async function(now, rabbit) {
       let nextRotationState = ns.rotationState === '1' ? '2' : '1';
 
       //modify user in rabbitmq
-      //TODO: open issue to create editUser method for rabbitmq api
       await rabbit.createUser(ns.username.concat('-').concat(nextRotationState), nextPass, ['taskcluster-pulse']);
 
       //modify ns in table

--- a/src/data.js
+++ b/src/data.js
@@ -77,15 +77,14 @@ Namespace.prototype.username = function() {
 };
 
 let setPulseUser = async function({username, password, namespace, rabbitManager, cfg}) {
-  await rabbitManager.createUser(username, password, ['taskcluster-pulse']);
+  await rabbitManager.createUser(username, password, cfg.app.userTags);
 
-  // TODO: make these configurable too
   await rabbitManager.setUserPermissions(
     username,
-    '/',
-    `^taskcluster/(exchanges|queues)/${namespace}/.*`,
-    `^taskcluster/(exchanges|queues)/${namespace}/.*`,
-    '^taskcluster/exchanges/.*',
+    cfg.app.virtualhost,
+    cfg.app.userConfigPermission.replace('{{namespace}}', namespace),
+    cfg.app.userWritePermission.replace('{{namespace}}', namespace),
+    cfg.app.userReadPermission.replace('{{namespace}}', namespace),
   );
 };
 

--- a/src/data.js
+++ b/src/data.js
@@ -32,6 +32,16 @@ let Namespace = Entity.configure({
   },
 });
 
+Namespace.prototype.json = function() {
+  return {
+    namespace: this.namespace,
+    username: Namespace.getRotationUsername(this),
+    password: this.password,
+    expires: this.expires.toJSON(),
+    contact: this.contact,
+  };
+};
+
 Namespace.getRotationUsername = function(ns) {
   assert(ns instanceof Namespace, 'ns must be a namespace');
   return ns.username.concat('-').concat(ns.rotationState);

--- a/src/main.js
+++ b/src/main.js
@@ -137,7 +137,7 @@ let load = loader({
 
       // rotate namespace username entries using delay
       debug('Rotating namespace entry at: %s, from before %s', new Date(), now);
-      let count = await Namespaces.rotate(now, rabbitManager);
+      let count = await Namespaces.rotate(now, cfg, rabbitManager);
       debug('Rotating %s namespace entries', count);
 
       monitor.count('rotate-namespaces.done');

--- a/src/main.js
+++ b/src/main.js
@@ -116,7 +116,6 @@ let load = loader({
     requires: ['cfg', 'Namespaces', 'monitor'],
     setup: async ({cfg, Namespaces, monitor}) => {
       let now = taskcluster.fromNow(cfg.app.namespacesExpirationDelay);
-      assert(!_.isNaN(now), 'Can\'t have NaN as now');
 
       // Expire namespace entries using delay
       debug('Expiring namespace entry at: %s, from before %s', new Date(), now);
@@ -133,7 +132,6 @@ let load = loader({
     requires: ['cfg', 'Namespaces', 'monitor', 'rabbitManager'],
     setup: async ({cfg, Namespaces, monitor, rabbitManager}) => {
       let now = taskcluster.fromNow(cfg.app.namespacesRotationDelay);
-      assert(!_.isNaN(now), 'Can\'t have NaN as now');
 
       // rotate namespace username entries using delay
       debug('Rotating namespace entry at: %s, from before %s', new Date(), now);

--- a/src/rabbitmanager.js
+++ b/src/rabbitmanager.js
@@ -89,8 +89,6 @@ class RabbitManager {
    *     Other custom tags are also allowed. Tags cannot contain comma (',').
    */
   async createUser(name, password, tags) {
-    assert(name);
-    assert(password);
     assert(tags instanceof Array);
 
     let payload = {

--- a/src/rabbitmanager.js
+++ b/src/rabbitmanager.js
@@ -78,6 +78,10 @@ class RabbitManager {
   /**
    * Create a user. All parameters are mandatory.
    *
+   * Note that the RabbitMQ API does not distinguish creating a user from updating
+   * a user.  If the username is already defined, it will be updated with the given
+   * password and tags.
+   *
    * @param {string} name               - Username.
    * @param {string} password           - The plaintext password.
    * @param {Array.<string>} tags       - A list of tags for the user. "administrator",

--- a/src/rabbitmanager.js
+++ b/src/rabbitmanager.js
@@ -230,7 +230,12 @@ class RabbitManager {
     await this.request(`permissions/${vhost}/${user}`, {method: 'delete'});
   }
 
-  /** Get a list of all queues. */
+  /** Get a list of all queues.
+   *
+   * This provides information directly from the RabbitMQ API - see
+   * https://cdn.rawgit.com/rabbitmq/rabbitmq-management/master/priv/www/doc/stats.html
+   * Note that the stats may not be available for newly-created queues.
+   */
   async queues() {
     return await this.request('queues');
   }

--- a/src/v1.js
+++ b/src/v1.js
@@ -132,8 +132,10 @@ api.declare({
 }, async function(req, res) {
   let {namespace} = req.params;
 
-  // TODO: verify user has scopes for the given contact information
-  // (requires deferAuth: true)
+  // NOTE: at the moment we do not confirm that the user has permission to send
+  // the given notification.  The possibility of abuse is remote (and would
+  // involve abusing pulse), but we can solve this problem if and when we have
+  // it.
 
   if (!isNamespaceValid(namespace, this.cfg)) {
     return invalidNamespaceResponse(req, res, this.cfg);

--- a/src/v1.js
+++ b/src/v1.js
@@ -97,6 +97,7 @@ api.declare({
 
   retval.namespaces = data.entries.map(ns => ({
     namespace: ns.namespace,
+    created: ns.created.toJSON(),
     contact: ns.contact,
   }));
 

--- a/src/v1.js
+++ b/src/v1.js
@@ -123,7 +123,7 @@ api.declare({
     'namespace good for a short time.  Clients should call this endpoint again',
     'at the re-claim time given in the response, as the password will be rotated',
     'soon after that time.  The namespace will expire, and any associated queues',
-    'and exchanges will be deleted, at the given expiration time',
+    'and exchanges will be deleted, at the given expiration time.',
   ].join('\n'),
 }, async function(req, res) {
   let {namespace} = req.params;
@@ -139,16 +139,8 @@ api.declare({
   }
 
   let newNamespace = await setNamespace(this, namespace, contact);
-  res.reply({
-    namespace:  newNamespace.namespace,
-    username:   this.Namespaces.getRotationUsername(newNamespace),
-    password:   newNamespace.password,
-    contact:    newNamespace.contact,
-    // TODO: return expiration, re-claim time
-    // note: returned re-claim time is not nextRotation, as calling
-    // before that rotation occurs could result in being told to call
-    // again immediately. Think carefully about which time is best.
-  });
+  res.reply(newNamespace.json());
+  // TODO: return re-claim time
 });
 
 /**

--- a/src/v1.js
+++ b/src/v1.js
@@ -180,18 +180,18 @@ function isNamespaceValid(namespace, cfg) {
  * If the requested namespace exists, update it with any user-supplied settnigs,
  * and return it.
  */
-async function setNamespace({rabbitManager, Namespaces}, namespace, {contact, expires}) {
+async function setNamespace({cfg, rabbitManager, Namespaces}, namespace, {contact, expires}) {
   let newNamespace;
   try {
     newNamespace = await Namespaces.create({
-      namespace:  namespace,
-      username:   namespace,
-      password:   slugid.v4(),
-      created:    new Date(),
-      expires:    expires,
+      namespace: namespace,
+      username: namespace,
+      password: slugid.v4(),
+      created: new Date(),
+      expires,
       rotationState:  '1',
-      nextRotation: taskcluster.fromNow('1 hour'),
-      contact:    contact,
+      nextRotation: taskcluster.fromNow(cfg.namespaceRotationInterval),
+      contact,
     });
 
     await rabbitManager.createUser(namespace.concat('-1'), newNamespace.password, ['taskcluster-pulse']);

--- a/test/data_test.js
+++ b/test/data_test.js
@@ -146,7 +146,7 @@ suite('Namespaces', () => {
     }
 
     test('rotate namespace - no entries', async () => {
-      await namespaces.rotate(taskcluster.fromNow('0 hours'), helper.rabbit);
+      await namespaces.rotate(taskcluster.fromNow('0 hours'), helper.cfg, helper.rabbit);
 
       let count = 0;
       await namespaces.scan({},
@@ -174,7 +174,7 @@ suite('Namespaces', () => {
         contact:  {},
       });
 
-      await namespaces.rotate(taskcluster.fromNow('0 hours'), helper.rabbit);
+      await namespaces.rotate(taskcluster.fromNow('0 hours'), helper.cfg, helper.rabbit);
 
       var ns = await namespaces.load({namespace: 'tcpulse-test-sample'});
       assert(ns, 'namespace should exist');
@@ -208,7 +208,7 @@ suite('Namespaces', () => {
         contact:  {},
       });
 
-      await namespaces.rotate(taskcluster.fromNow('0 hours'), helper.rabbit);
+      await namespaces.rotate(taskcluster.fromNow('0 hours'), helper.cfg, helper.rabbit);
 
       var ns1 = await namespaces.load({namespace: 'tcpulse-test-sample1'});
       var ns2 = await namespaces.load({namespace: 'tcpulse-test-sample2'});
@@ -247,7 +247,7 @@ suite('Namespaces', () => {
         contact:  {},
       });
 
-      await namespaces.rotate(taskcluster.fromNow('0 hours'), helper.rabbit);
+      await namespaces.rotate(taskcluster.fromNow('0 hours'), helper.cfg, helper.rabbit);
 
       var ns1 = await namespaces.load({namespace: 'tcpulse-test-sample1'});
       var ns2 = await namespaces.load({namespace: 'tcpulse-test-sample2'});
@@ -280,11 +280,11 @@ suite('Namespaces', () => {
         assert(ns1.rotationState === state, 'tcpulse-test-sample1 should have rotated state');
       };
 
-      await namespaces.rotate(taskcluster.fromNow('0 days'), helper.rabbit);
+      await namespaces.rotate(taskcluster.fromNow('0 days'), helper.cfg, helper.rabbit);
       await assertRotationState('2');
-      await namespaces.rotate(taskcluster.fromNow('1 day'), helper.rabbit);
+      await namespaces.rotate(taskcluster.fromNow('1 day'), helper.cfg, helper.rabbit);
       await assertRotationState('1');
-      await namespaces.rotate(taskcluster.fromNow('2 days'), helper.rabbit);
+      await namespaces.rotate(taskcluster.fromNow('2 days'), helper.cfg, helper.rabbit);
       await assertRotationState('2');
     });
   });

--- a/test/helper.js
+++ b/test/helper.js
@@ -20,6 +20,7 @@ let testclients = {
 
 // Create and export helper object
 let helper = module.exports = {};
+helper.cfg = cfg;
 
 let webServer = null;
 

--- a/test/rabbitmanager_test.js
+++ b/test/rabbitmanager_test.js
@@ -158,14 +158,8 @@ suite('RabbitManager', function() {
     const queues = await helper.rabbit.queues();
 
     assert(queues instanceof Array);
-    assert(queues.length > 0);
-    // TODO: the rabbit server doesn't return these keys for brand-new queues; consumers
-    // of this API will need to be careful to handle that possibility
-    // assert(_.has(queues[0], 'memory')); -- it doesn't have this..
-    // assert(_.has(queues[0], 'messages')); -- it doesn't have this..
-    // assert(_.has(queues[0], 'messages_details')); -- it doesn't have this..
-    // assert(_.has(queues[0], 'messages_ready')); -- it doesn't have this..
-    assert(_.has(queues[0], 'name'));
+    assert(queues.length === 1);
+    assert(queues[0].name === queuenames[0]);
   });
 
   test('createGetDeleteQueue', async () => {


### PR DESCRIPTION
This brings the service up to snuff, but doesn't address issues with the monitor.

Highlights:
* users are told when to request a new password
* AMQP parameters are configurable, rather than hard-coded
* claims update the existing namespace parameters (especially expires)

I think that with this, plus getting RabbitMonitor up and running, and fixing PulseGuardian to prohibit usernames starting with "taskcluster-", we will be ready to put this into production.  Then we need to write support in pulse-publisher :)