### PR TITLE
Bug 1352470: actually delete stuff

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -12,7 +12,8 @@ defaults:
     # the virtualhost to manage
     virtualhost: /
 
-    # permissions to give to users; {{namespace}} is replaced by the namespace
+    # permissions to give to users; {{namespace}} is replaced by the namespace.  Note that
+    # when users are deleted, anything that user had permission to configure is also deleted!
     userConfigPermission: "^(queue/{{namespace}}/.*|exchange/{{namespace}}/.*)"
     userWritePermission: "^(queue/{{namespace}}/.*|exchange/{{namespace}}/.*)"
     userReadPermission: "^(queue/{{namespace}}/.*|exchange/.*)"

--- a/config.yml
+++ b/config.yml
@@ -78,6 +78,10 @@ test:
     amqpUrl: 'amqp://localhost'
     namespacePrefix: 'tcpulse-test-'
     namespaceRotationInterval: '1 hour'
+    virtualhost: /
+    userConfigPermission: "^(queue/{{namespace}}/.*|exchange/{{namespace}}/.*)"
+    userWritePermission: "^(queue/{{namespace}}/.*|exchange/{{namespace}}/.*)"
+    userReadPermission: "^(queue/{{namespace}}/.*|exchange/.*)"
 
   taskcluster:
     credentials:

--- a/src/main.js
+++ b/src/main.js
@@ -53,7 +53,7 @@ let load = loader({
     }),
   },
 
-  Namespaces: {
+  Namespace: {
     requires: ['cfg', 'monitor'],
     setup: async ({cfg, monitor}) => {
       var ns = data.Namespace.setup({
@@ -69,9 +69,9 @@ let load = loader({
   },
 
   api: {
-    requires: ['cfg', 'monitor', 'validator', 'rabbitManager', 'Namespaces'],
-    setup: ({cfg, monitor, validator, rabbitManager, Namespaces}) => v1.setup({
-      context:          {cfg, rabbitManager, Namespaces},
+    requires: ['cfg', 'monitor', 'validator', 'rabbitManager', 'Namespace'],
+    setup: ({cfg, monitor, validator, rabbitManager, Namespace}) => v1.setup({
+      context:          {cfg, rabbitManager, Namespace},
       authBaseUrl:      cfg.taskcluster.authBaseUrl,
       publish:          process.env.NODE_ENV === 'production',
       baseUrl:          cfg.server.publicUrl + '/v1',
@@ -113,13 +113,13 @@ let load = loader({
   },
 
   'expire-namespaces':{
-    requires: ['cfg', 'Namespaces', 'monitor'],
-    setup: async ({cfg, Namespaces, monitor}) => {
+    requires: ['cfg', 'Namespace', 'monitor'],
+    setup: async ({cfg, Namespace, monitor}) => {
       let now = taskcluster.fromNow(cfg.app.namespacesExpirationDelay);
 
       // Expire namespace entries using delay
       debug('Expiring namespace entry at: %s, from before %s', new Date(), now);
-      let count = await Namespaces.expire(now);
+      let count = await Namespace.expire(now);
       debug('Expired %s namespace entries', count);
 
       monitor.count('expire-namespaces.done');
@@ -129,13 +129,13 @@ let load = loader({
   },
 
   'rotate-namespaces':{
-    requires: ['cfg', 'Namespaces', 'monitor', 'rabbitManager'],
-    setup: async ({cfg, Namespaces, monitor, rabbitManager}) => {
+    requires: ['cfg', 'Namespace', 'monitor', 'rabbitManager'],
+    setup: async ({cfg, Namespace, monitor, rabbitManager}) => {
       let now = taskcluster.fromNow(cfg.app.namespacesRotationDelay);
 
       // rotate namespace username entries using delay
       debug('Rotating namespace entry at: %s, from before %s', new Date(), now);
-      let count = await Namespaces.rotate(now, cfg, rabbitManager);
+      let count = await Namespace.rotate(now, cfg, rabbitManager);
       debug('Rotating %s namespace entries', count);
 
       monitor.count('rotate-namespaces.done');

--- a/src/maintenance.js
+++ b/src/maintenance.js
@@ -10,9 +10,9 @@ let setPulseUser = async function({username, password, namespace, rabbitManager,
   await rabbitManager.setUserPermissions(
     username,
     cfg.app.virtualhost,
-    cfg.app.userConfigPermission.replace(/{{namespace}}/, namespace),
-    cfg.app.userWritePermission.replace(/{{namespace}}/, namespace),
-    cfg.app.userReadPermission.replace(/{{namespace}}/, namespace),
+    cfg.app.userConfigPermission.replace(/{{namespace}}/g, namespace),
+    cfg.app.userWritePermission.replace(/{{namespace}}/g, namespace),
+    cfg.app.userReadPermission.replace(/{{namespace}}/g, namespace),
   );
 };
 

--- a/src/maintenance.js
+++ b/src/maintenance.js
@@ -80,7 +80,10 @@ module.exports.claim = async function({Namespace, cfg, rabbitManager, namespace,
 module.exports.delete = async function({Namespace, rabbitManager, cfg, namespace}) {
   let debug = Debug('delete');
 
-  // use the configuration regexp to determine if an object is owned by this user
+  // use the configuration regexp to determine if an object is owned by this
+  // user, being careful to check that the namespace doesn't contain any funny
+  // charcters (this is checked when the namespace is created, too)
+  assert(namespace.length <= 64 && /^[A-Za-z0-9_-]+$/.test(namespace));
   let owned = new RegExp(cfg.app.userConfigPermission.replace(/{{namespace}}/g, namespace));
 
   // find the user's exchanges and queues

--- a/src/maintenance.js
+++ b/src/maintenance.js
@@ -1,0 +1,125 @@
+let taskcluster = require('taskcluster-client');
+let _ = require('lodash');
+let slugid = require('slugid');
+let assert = require('assert');
+let Debug = require('debug');
+
+let setPulseUser = async function({username, password, namespace, rabbitManager, cfg}) {
+  await rabbitManager.createUser(username, password, cfg.app.userTags);
+
+  await rabbitManager.setUserPermissions(
+    username,
+    cfg.app.virtualhost,
+    cfg.app.userConfigPermission.replace(/{{namespace}}/, namespace),
+    cfg.app.userWritePermission.replace(/{{namespace}}/, namespace),
+    cfg.app.userReadPermission.replace(/{{namespace}}/, namespace),
+  );
+};
+
+/*
+ * Attempt to create a new namespace entry and associated Rabbit user.
+ * If the requested namespace exists, update it with any user-supplied settings,
+ * and return it.
+ */
+module.exports.claim = async function({Namespace, cfg, rabbitManager, namespace, contact, expires}) {
+  let newNamespace;
+  let created;
+
+  try {
+    newNamespace = await Namespace.create({
+      namespace: namespace,
+      username: namespace,
+      password: slugid.v4(),
+      created: new Date(),
+      expires,
+      rotationState:  '1',
+      nextRotation: taskcluster.fromNow(cfg.app.namespaceRotationInterval),
+      contact,
+    });
+
+    created = true;
+  } catch (err) {
+    if (err.code !== 'EntityAlreadyExists') {
+      throw err;
+    }
+
+    created = false;
+
+    // get the existing row
+    newNamespace = await Namespace.load({namespace: namespace});
+
+    // If this claim contains different information, update it accordingly
+    if (!_.isEqual(
+      {expires: newNamespace.expires, contact: newNamespace.contact},
+      {expires, contact})) {
+      await newNamespace.modify(entity => {
+        entity.expires = expires;
+        entity.contact = contact;
+      });
+
+      newNamespace = await Namespace.load({namespace: namespace});
+    }
+  }
+
+  if (created) {
+    // set up the first user as active,
+    await setPulseUser({
+      username: `${namespace}-1`,
+      password: newNamespace.password,
+      namespace, cfg, rabbitManager});
+    // ..and the second user as inactive (empty string means no logins allowed)
+    await setPulseUser({
+      username: `${namespace}-2`,
+      password: '',
+      namespace, cfg, rabbitManager});
+  }
+
+  return newNamespace;
+};
+
+module.exports.expire = async function({Namespace, now}) {
+  assert(now instanceof Date, 'now must be given as option');
+  let count = 0;
+  await Namespace.scan({
+    expires: Namespace.op.lessThan(now),
+  }, {
+    limit:            250, // max number of concurrent delete operations
+    handler:          (ns) => {
+      count++;
+      return ns.remove(true);
+    },
+  });
+  return count;
+};
+
+module.exports.rotate = async function({Namespace, now, cfg, rabbitManager}) {
+  let count = 0;
+  let debug = Debug('rotate');
+
+  await Namespace.scan({
+    nextRotation: Namespace.op.lessThan(now),
+  }, {
+    limit:            250, // max number of concurrent modify operations
+    handler:          async (ns) => {
+      count++;
+      debug(`rotating ${ns.namespace}`);
+      let password = slugid.v4();
+      let rotationState = ns.rotationState === '1' ? '2' : '1';
+
+      // modify user in rabbitmq
+      await setPulseUser({
+        username: `${ns.namespace}-${rotationState}`,
+        password,
+        namespace: ns.namespace,
+        cfg, rabbitManager});
+
+      // modify ns in table
+      await ns.modify((entity) => {
+        entity.rotationState = rotationState;
+        entity.nextRotation = taskcluster.fromNow(cfg.app.namespaceRotationInterval),
+        entity.password = password;
+      });
+    },
+  });
+  return count;
+};

--- a/src/rabbitmanager.js
+++ b/src/rabbitmanager.js
@@ -120,11 +120,64 @@ class RabbitManager {
     return await this.request('users');
   }
 
+  /** Get information of an invididual user.
+   *
+   * @param {string} name       - user name.
+   */
+  async user(name) {
+    return await this.request(`users/${name}`);
+  }
+
   /**
    * Get a list of all exchanges
    */
   async exchanges() {
     return await this.request('exchanges');
+  }
+
+  /**
+   * Get information of an individual exchange.
+   *
+   * @param {string} name       - Name of the queue.
+   * @param {string} vhost      - Virtual host.
+   * @default
+   */
+  async exchange(name, vhost='/') {
+    assert(name);
+    assert(vhost);
+
+    [name, vhost] = this.encode([name, vhost]);
+    return await this.request(`exchanges/${vhost}/${name}`);
+  }
+
+  /**
+   * Create an exchange.
+   *
+   * @param {string} name       - Name of the exchange.
+   * @param {Object} options    - Settings of the exchange (default is {type: 'direct'}; all keys are optional).
+   * @param {string} vhost      - Virtual host (default is "/").
+   */
+  async createExchange(name, options={type: 'direct'}, vhost='/') {
+    [name, vhost] = this.encode([name, vhost]);
+    return await this.request(`exchanges/${vhost}/${name}`, {
+      body: JSON.stringify(options),
+      method: 'put',
+    });
+  }
+
+  /**
+   * Delete an exchange
+   *
+   * @param {string} name       - Name of the exchange.
+   * @param {string} vhost      - Virtual host.
+   * @default
+   */
+  async deleteExchange(name, vhost='/') {
+    assert(name);
+    assert(vhost);
+
+    [name, vhost] = this.encode([name, vhost]);
+    return await this.request(`exchanges/${vhost}/${name}`, {method: 'delete'});
   }
 
   /**

--- a/src/v1.js
+++ b/src/v1.js
@@ -122,7 +122,7 @@ api.declare({
     return invalidNamespaceResponse(req, res, this.cfg);
   }
 
-  let ns = await this.Namespace.load({namespace});
+  let ns = await this.Namespace.load({namespace}, true);
   if (!ns) {
     return res.reportError('ResourceNotFound', 'No such namespace', {});
   }

--- a/src/v1.js
+++ b/src/v1.js
@@ -1,9 +1,8 @@
 let API = require('taskcluster-lib-api');
 let assert = require('assert');
 let debug = require('debug')('taskcluster-pulse');
-let taskcluster = require('taskcluster-client');
-let slugid = require('slugid');
 let _ = require('lodash');
+let {claim} = require('./maintenance');
 
 let api = new API({
   title: 'Pulse Management Service',
@@ -163,7 +162,8 @@ api.declare({
     return invalidNamespaceResponse(req, res, this.cfg);
   }
 
-  let newNamespace = await this.Namespace.claim({
+  let newNamespace = await claim({
+    Namespace: this.Namespace,
     cfg: this.cfg,
     rabbitManager: this.rabbitManager,
     namespace,

--- a/src/v1.js
+++ b/src/v1.js
@@ -19,7 +19,7 @@ let api = new API({
   context: [
     'cfg',
     'rabbitManager',
-    'Namespaces',
+    'Namespace',
   ],
   errorCodes: {
     InvalidNamespace: 400,
@@ -93,7 +93,7 @@ api.declare({
   }
 
   var retval = {};
-  var data = await this.Namespaces.scan({}, {limit, continuation});
+  var data = await this.Namespace.scan({}, {limit, continuation});
 
   retval.namespaces = data.entries.map(ns =>
     ns.json({cfg: this.cfg, includePassword: false}));
@@ -123,7 +123,7 @@ api.declare({
     return invalidNamespaceResponse(req, res, this.cfg);
   }
 
-  let ns = await this.Namespaces.load({namespace});
+  let ns = await this.Namespace.load({namespace});
   if (!ns) {
     return res.reportError('ResourceNotFound', 'No such namespace', {});
   }
@@ -163,7 +163,7 @@ api.declare({
     return invalidNamespaceResponse(req, res, this.cfg);
   }
 
-  let newNamespace = await this.Namespaces.claim({
+  let newNamespace = await this.Namespace.claim({
     cfg: this.cfg,
     rabbitManager: this.rabbitManager,
     namespace,

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -6,19 +6,19 @@ suite('API', () => {
   let slugid = require('slugid');
   let _ = require('lodash');
 
-  let namespaces;
+  let Namespace;
 
   setup(async () => {
     //set up the namespace entities
-    namespaces = await load('Namespaces', {profile: 'test', process: 'test'});
+    Namespace = await load('Namespace', {profile: 'test', process: 'test'});
 
     //ensureTable actually instantiates the table if non-existing. Supposed to be idempotent, but not
-    await namespaces.ensureTable();
+    await Namespace.ensureTable();
   });
 
   teardown(async () => {
     //remove the namespace entities
-    await namespaces.removeTable();
+    await Namespace.removeTable();
   });
 
   test('ping', () => {
@@ -175,7 +175,7 @@ suite('API', () => {
         });
       }
       let count = 0;
-      await namespaces.scan({},
+      await Namespace.scan({},
         {
           limit:            250,
           handler:          ns => count++,

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -199,6 +199,32 @@ suite('API', () => {
     });
   });
 
+  suite('deleteNamespace', function() {
+    test('deletes namespace', async () => {
+      await helper.pulse.claimNamespace('tcpulse-test-sample', {
+        expires: taskcluster.fromNow('1 day'),
+        contact: {
+          method: 'email',
+          payload: {address: 'a@a.com'},
+        },
+      });
+
+      await helper.pulse.deleteNamespace('tcpulse-test-sample');
+
+      let got404 = false;
+      try {
+        await helper.pulse.namespace('tcpulse-test-sample');
+      } catch (err) {
+        if (err.statusCode === 404) {
+          got404 = true;
+        } else {
+          throw err;
+        }
+      }
+      assert(got404);
+    });
+  });
+
   suite('listNamespaces', function() {
     test('returns namespaces', async () => {
       // create a bunch of namespaces

--- a/test/data_test.js
+++ b/test/data_test.js
@@ -1,4 +1,4 @@
-suite('Namespaces', () => {
+suite('Namespace', () => {
   let assert = require('assert');
   let taskcluster = require('taskcluster-client');
   let helper = require('./helper');
@@ -9,7 +9,7 @@ suite('Namespaces', () => {
 
   setup(async () => {
     //set up the namespace entities
-    namespaces = await load('Namespaces', {profile: 'test', process: 'test'});
+    namespaces = await load('Namespace', {profile: 'test', process: 'test'});
 
     //ensureTable actually instantiates the table if non-existing. Supposed to be idempotent, but not
     await namespaces.ensureTable();

--- a/test/maintenance_test.js
+++ b/test/maintenance_test.js
@@ -66,8 +66,12 @@ suite('Namespace', () => {
       await shouldFail(() => helper.rabbit.queue('queue/bar/def'));
       await helper.rabbit.exchange('exchange/notbar/events'); // not deleted!
       await shouldFail(() => helper.rabbit.exchange('exchange/bar/events'));
+
       ns = await Namespace.load({namespace: 'bar'}, true);
       assert.equal(ns, undefined);
+
+      helper.rabbit.deleteQueue('queue/notbar/abc');
+      helper.rabbit.deleteExchange('exchange/notbar/events');
     });
   });
 

--- a/test/rabbitmanager_test.js
+++ b/test/rabbitmanager_test.js
@@ -155,11 +155,12 @@ suite('RabbitManager', function() {
   test('queues', async () => {
     await helper.rabbit.createQueue(queuenames[0]);
 
-    const queues = await helper.rabbit.queues();
+    let queues = await helper.rabbit.queues();
 
+    // at least one of these is the created queue
     assert(queues instanceof Array);
-    assert(queues.length === 1);
-    assert(queues[0].name === queuenames[0]);
+    queues = _.filter(queues, {name: queuenames[0]});
+    assert.equal(queues.length, 1);
   });
 
   test('createGetDeleteQueue', async () => {


### PR DESCRIPTION
Aside from the review, can you double-check my logic that this won't, uh, "accidentally" delete all the exchanges and queues on the pulse server?

The production pulse user has its "config" set appropriately to prohibit deleting non-managed exchanges and queues, but as an administrator using the management API I don't know if that permission applies.

I could land a variant of this which just logs the queues and exchanges it wants to delete, and then try it out.  But I think the unit test already does that.  ??