### PR TITLE
Remove users forcibly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 sudo: required # We must use sudo here to have rabbitmq running :(
+dist: zesty # for a newer rabbtimq
 env:
   global:
   - DEBUG='*,-babel*,-mocha*,-eslint*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: required # We must use sudo here to have rabbitmq running :(
 env:
   global:
-  - DEBUG='base:app:request,auth:*,server,test:*,pulse'
+  - DEBUG='*,-babel*,-mocha*,-eslint*'
   - CXX=g++-4.8
   - RABBIT_USERNAME=guest
   - RABBIT_PASSWORD=guest

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "typed-env-config": "^1.1.0"
   },
   "devDependencies": {
+    "amqplib": "^0.5.1",
     "jsdoc": "^3.4.2",
     "jsdoc-strip-async-await": "^0.1.0",
     "mocha": "^3.0.2",

--- a/src/rabbitmanager.js
+++ b/src/rabbitmanager.js
@@ -374,6 +374,28 @@ class RabbitManager {
       method: 'post',
     });
   }
+
+  /** Get a list of all connections for a vhost.
+   *
+   * This provides information directly from the RabbitMQ API - see
+   * https://cdn.rawgit.com/rabbitmq/rabbitmq-management/master/priv/www/doc/stats.html
+   */
+  async connections(vhost='/') {
+    vhost = this.encode(vhost);
+    return await this.request(`vhosts/${vhost}/connections`);
+  }
+
+  /** Forcibly terminate a connection
+   */
+  async terminateConnection(name, reason) {
+    name = this.encode(name);
+    return await this.request(`connections/${name}`, {
+      method: 'delete',
+      headers: {
+        'X-Reason': reason,
+      },
+    });
+  }
 }
 
 module.exports = RabbitManager;

--- a/src/v1.js
+++ b/src/v1.js
@@ -150,7 +150,6 @@ api.declare({
     contact: req.body.contact,
     expires: new Date(req.body.expires),
   });
-  console.log(newNamespace.json({cfg: this.cfg, includePassword: true}));
   res.reply(newNamespace.json({cfg: this.cfg, includePassword: true}));
 });
 


### PR DESCRIPTION
There's a minor concern here in that connections do not appear immediately in the management API.  They seem to appear after some ~5-second periodic task finds them.

So there's a scenario here that could get a user access after they have been deleted:
 - periodic task runs
 - delete function polls for connections
 - user connects
 - delete function sees no connections, deletes nothing
 - user remains connected

Two things might then happen: if the user has an exclusive queue, then the delete operation will fail (and thus be retried next time).  If the user does not have an exclusive queue, then they have perpetual access until the connection fails (in my testing, that user can still create an exchange, so apparently the ACLs are associated with the connection?).  That seems less than good, but I'm not sure how we could detect it?