### PR TITLE
remove exchanges() API endpoint

### DIFF
--- a/src/v1.js
+++ b/src/v1.js
@@ -47,26 +47,6 @@ api.declare({
 });
 
 api.declare({
-  method:     'get',
-  route:      '/exchanges',
-  name:       'exchanges',
-  title:      'Rabbit Exchanges',
-  output:     'exchanges-response.json',
-  stability:  'experimental',
-  description: [
-    'Get a list of all exchanges in the rabbit cluster.  This will include exchanges',
-    'not managed by this service, if any exist.',
-  ].join('\n'),
-}, async function(req, res) {
-  res.reply(
-    _.map(
-      await this.rabbitManager.exchanges(),
-      elem => _.pick(elem, ['name', 'vhost', 'type', 'durable', 'auto_delete', 'internal', 'arguments'])
-    )
-  );
-});
-
-api.declare({
   method:         'get',
   route:          '/namespaces',
   name:           'listNamespaces',

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -29,10 +29,6 @@ suite('API', () => {
     return helper.pulse.overview();
   }));
 
-  test('exchanges', helper.requiresRabbitMq(() => {
-    return helper.pulse.exchanges();
-  }));
-
   suite('claimNamespace', function() {
     test('success', () => {
       return helper.pulse.claimNamespace('tcpulse-test-sample', {


### PR DESCRIPTION
This method does not currently accept pagination options, but it really
should.  The underlying rabbitmq management API has continuation support
landed, but not in a released version and not in a version of RbabitMQ
we are running.  Providing the endpoint without pagination would lead to
a breaking API change later.  Emulating pagination is possible, but we
currently do not have an anticipated use for this endpoint and it
returns a lot of useless information (test exchanges, etc.), so that
effort will not be worthwhile.  So, just delete it.

Fixes #53.