### PR TITLE
shift to version 8.0.0 of taskcluster-lib-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "request-promise": "^4.2.2",
     "slugid": "^1.1.0",
     "taskcluster-client": "^3.1.1",
-    "taskcluster-lib-api": "7.0.1",
+    "taskcluster-lib-api": "8.0.0",
     "taskcluster-lib-app": "^2.1.0",
     "taskcluster-lib-docs": "^4.0.0",
     "taskcluster-lib-iterate": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2666,9 +2666,9 @@ taskcluster-client@^3.0.3, taskcluster-client@^3.1.0, taskcluster-client@^3.1.1:
     slugid "^1.1.0"
     superagent "~3.8.1"
 
-taskcluster-lib-api@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-7.0.1.tgz#7ce01219c2faaba0ec016578241cfdf541a95d89"
+taskcluster-lib-api@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-8.0.0.tgz#d459870d48134a3fdd14fc1c92b244807d6b7c2b"
   dependencies:
     ajv "^5.3.0"
     aws-sdk "^2.151.0"


### PR DESCRIPTION
Upgrades version of tc-lib-api to 8.0.0
@djmitche Please review. Thanks. :)