### PR TITLE
Bug 1490473 - add a mockMaintenance mode

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -9,6 +9,9 @@ defaults:
     rabbitQueueTableName: 'PulseRabbitQueues'
     rabbitQueueExpirationDelay: '- 24 hours' # This means we re-send alerts at most once a day
 
+    # if true, maintenance will just log about what it would do, and not actually do it.
+    mockMaintenance: !env:bool MOCK_MAINTENANCE
+
     # namespaces are rotated at this time interval.
     namespaceRotationInterval: '1 hour'
 


### PR DESCRIPTION
I get the same number of test failures when I set `MOCK_MAINTENANCE=true` as when I comment out the potentially dangerous `deleteXyz` operations, so I'm reasonably confident that this logic is correct.