### PR TITLE
Bug 1495918 - use `NO_TEST_SKIP: "true"` rather than `NO_TEST_SKIP: true` in yaml files

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -17,7 +17,7 @@ tasks:
       # this image was built from test/Dockerfile; it's a mashup of the given node and rabbitmq images..
       image: "taskcluster/taskcluster-pulse-test:node-8.11.2-rabbitmq-3.6.15-management@sha256:727392ce1d90f848496792636593fca72e9304b0c6064b401aeefd4bf1a27c26"
       env:
-        NO_TEST_SKIP: true
+        NO_TEST_SKIP: "true"
         # this affects the image, and makes it allow guest:guest access to the /test vhost
         RABBITMQ_DEFAULT_VHOST: /test
       features:


### PR DESCRIPTION
In task payloads, environment variables must be strings, not booleans.

This fixes `NO_TEST_SKIP` environment variable in the task definition to be a string.

See [bug 1495918](https://bugzilla.mozilla.org/show_bug.cgi?id=1495918#c6) for context.