### PR TITLE
Bug 1498700 - support a usernamePrefix to manage different usernames

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -26,6 +26,12 @@ defaults:
     # tags to be applied to new users
     userTags: [taskcluster-pulse]
 
+    # Every username will have this value as a prefix, before the namespace.
+    # Use this to allow several taskcluster-pulse instances to co-exist within
+    # the same RabbitMQ service but in different vhosts (since users are not
+    # scoped to vhosts, the names must be globally unique)
+    usernamePrefix: !env USERNAME_PREFIX
+
     # If given, all namespaces must begin with this string; and only
     # matching queues and exchanges will be monitored.  Use this to
     # allow taskcluster-pulse to "share" a rabbitmq virtualhost with other

--- a/src/data.js
+++ b/src/data.js
@@ -77,7 +77,7 @@ Namespace.prototype.json = function({cfg, includePassword}) {
 
     rv.connectionString = buildConnectionString({
       protocol: cfg.app.amqpProtocol,
-      username: this.username(),
+      username: this.username(cfg, this.rotationState),
       password: this.password,
       hostname: cfg.app.amqpHostname,
       port: cfg.app.amqpPort,
@@ -89,8 +89,8 @@ Namespace.prototype.json = function({cfg, includePassword}) {
   return rv;
 };
 
-Namespace.prototype.username = function() {
-  return `${this.namespace}-${this.rotationState}`;
+Namespace.prototype.username = function(cfg, rotationState) {
+  return `${cfg.app.usernamePrefix || ''}${this.namespace}-${rotationState}`;
 };
 
 /**

--- a/test/maintenance_test.js
+++ b/test/maintenance_test.js
@@ -13,6 +13,9 @@ const sinon = require('sinon');
 const debug = Debug('maintenance-test');
 
 helper.secrets.mockSuite('Maintenance', ['taskcluster'], function(mock, skipping) {
+  suiteSetup(() => {
+    helper.load.cfg('app.usernamePrefix', 'PFX-');
+  });
   helper.withRabbitMq(mock, skipping);
   helper.withEntities(mock, skipping);
   helper.withServer(mock, skipping);
@@ -121,7 +124,6 @@ helper.secrets.mockSuite('Maintenance', ['taskcluster'], function(mock, skipping
 
       await helper.Namespace.create({
         namespace: 'tcpulse-test-sample',
-        username: 'tcpulse-test-sample',
         password: old_pass,
         created:  new Date(),
         expires:  taskcluster.fromNow('1 hour'),
@@ -149,7 +151,6 @@ helper.secrets.mockSuite('Maintenance', ['taskcluster'], function(mock, skipping
 
       await helper.Namespace.create({
         namespace: 'tcpulse-test-sample1',
-        username: 'tcpulse-test-sample',
         password: old_pass,
         created:  new Date(),
         expires:  taskcluster.fromNow('1 hour'),
@@ -160,7 +161,6 @@ helper.secrets.mockSuite('Maintenance', ['taskcluster'], function(mock, skipping
 
       await helper.Namespace.create({
         namespace: 'tcpulse-test-sample2',
-        username: 'tcpulse-test-sample',
         password: old_pass,
         created:  new Date(),
         expires:  taskcluster.fromNow('1 hour'),
@@ -193,7 +193,6 @@ helper.secrets.mockSuite('Maintenance', ['taskcluster'], function(mock, skipping
 
       await helper.Namespace.create({
         namespace: 'tcpulse-test-sample1',
-        username: 'tcpulse-test-sample',
         password: old_pass,
         created:  new Date(),
         expires:  taskcluster.fromNow('1 hour'),
@@ -204,7 +203,6 @@ helper.secrets.mockSuite('Maintenance', ['taskcluster'], function(mock, skipping
 
       await helper.Namespace.create({
         namespace: 'tcpulse-test-sample2',
-        username: 'tcpulse-test-sample',
         password: old_pass,
         created:  new Date(),
         expires:  taskcluster.fromNow('1 hour'),
@@ -236,7 +234,6 @@ helper.secrets.mockSuite('Maintenance', ['taskcluster'], function(mock, skipping
 
       await helper.Namespace.create({
         namespace: 'tcpulse-test-sample1',
-        username: 'tcpulse-test-sample',
         password: old_pass,
         created:  new Date(),
         expires:  taskcluster.fromNow('1 hour'),
@@ -423,9 +420,9 @@ helper.secrets.mockSuite('Maintenance', ['taskcluster'], function(mock, skipping
         await testing.poll(async () => {
           let connectedUsers = _.map(await rabbitManager.connections(vhost), 'user');
           assert(_.includes(connectedUsers, 'guest'));
-          assert(_.includes(connectedUsers, 'tcpulse-test-m1-1'));
-          assert(_.includes(connectedUsers, 'tcpulse-test-m2-1'));
-          assert(_.includes(connectedUsers, 'tcpulse-test-m3-1'));
+          assert(_.includes(connectedUsers, 'PFX-tcpulse-test-m1-1'));
+          assert(_.includes(connectedUsers, 'PFX-tcpulse-test-m2-1'));
+          assert(_.includes(connectedUsers, 'PFX-tcpulse-test-m3-1'));
         });
 
         await maintenance.expire({
@@ -446,9 +443,9 @@ helper.secrets.mockSuite('Maintenance', ['taskcluster'], function(mock, skipping
         await testing.poll(async () => {
           let connectedUsers = _.map(await rabbitManager.connections(vhost), 'user');
           assert(_.includes(connectedUsers, 'guest'));
-          assert(_.includes(connectedUsers, 'tcpulse-test-m1-1'));
-          assert(!_.includes(connectedUsers, 'tcpulse-test-m2-1')); // killed
-          assert(!_.includes(connectedUsers, 'tcpulse-test-m3-1')); // killed
+          assert(_.includes(connectedUsers, 'PFX-tcpulse-test-m1-1'));
+          assert(!_.includes(connectedUsers, 'PFX-tcpulse-test-m2-1')); // killed
+          assert(!_.includes(connectedUsers, 'PFX-tcpulse-test-m3-1')); // killed
         });
       } finally {
         for (let dyingConn of [dyingConnection2, dyingConnection3]) {


### PR DESCRIPTION
This allows multiple tc-pulse instance to co-exist on different vhosts.
Without this, they would all try to manage the same usernames, leading
to some unhappiness at best.

This also makes pulseNamespace a config parameter.  I've already set both in Heroku.